### PR TITLE
Sorting of hbase keys (do not merge)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: java
 jdk:
   - oraclejdk7

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/Document.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/Document.java
@@ -36,6 +36,8 @@ public class Document implements Serializable {
     @JsonProperty
     private long timestamp;
 
+    private DocumentMetadata metadata;
+
     @NotNull
     @JsonProperty
     private JsonNode data;
@@ -47,6 +49,13 @@ public class Document implements Serializable {
     public Document(String id, long timestamp, JsonNode data) {
         this.id = id;
         this.timestamp = timestamp;
+        this.data = data;
+    }
+
+    public Document(String id, long timestamp, DocumentMetadata metadata, JsonNode data) {
+        this.id = id;
+        this.timestamp = timestamp;
+        this.metadata = metadata;
         this.data = data;
     }
 
@@ -72,5 +81,23 @@ public class Document implements Serializable {
 
     public void setTimestamp(long timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public DocumentMetadata getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(DocumentMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public String toString() {
+        return "Document{" +
+                "id='" + id + '\'' +
+                ", timestamp=" + timestamp +
+                ", metadata=" + metadata +
+                ", data=" + data +
+                '}';
     }
 }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/DocumentMetadata.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/DocumentMetadata.java
@@ -1,0 +1,41 @@
+package com.flipkart.foxtrot.common;
+
+/**
+ * Metadata for a document
+ */
+public class DocumentMetadata {
+    private String id;
+    private String rowKey;
+
+    public DocumentMetadata() {
+    }
+
+    public DocumentMetadata(String id, String rowKey) {
+        this.id = id;
+        this.rowKey = rowKey;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getRowKey() {
+        return rowKey;
+    }
+
+    public void setRowKey(String rowKey) {
+        this.rowKey = rowKey;
+    }
+
+    @Override
+    public String toString() {
+        return "DocumentMetadata{" +
+                "id='" + id + '\'' +
+                ", rowKey='" + rowKey + '\'' +
+                '}';
+    }
+}

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/DataStore.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/DataStore.java
@@ -26,8 +26,8 @@ import java.util.List;
  * Time: 9:17 PM
  */
 public interface DataStore {
-    public void save(final Table table, final Document document) throws DataStoreException;
-    public void save(final Table table, final List<Document> documents) throws DataStoreException;
+    public Document save(final Table table, final Document document) throws DataStoreException;
+    public List<Document> save(final Table table, final List<Document> documents) throws DataStoreException;
     public Document get(final Table table, final String id) throws DataStoreException;
     public List<Document> get(final Table table, final List<String> ids) throws DataStoreException;
 }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/parsers/ElasticsearchMappingParser.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/parsers/ElasticsearchMappingParser.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flipkart.foxtrot.common.FieldType;
 import com.flipkart.foxtrot.common.FieldTypeMapping;
+import com.flipkart.foxtrot.core.querystore.impl.ElasticsearchUtils;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 
 import java.io.IOException;
@@ -48,6 +49,9 @@ public class ElasticsearchMappingParser {
         Iterator<Map.Entry<String, JsonNode>> iterator = jsonNode.fields();
         while (iterator.hasNext()) {
             Map.Entry<String, JsonNode> entry = iterator.next();
+            if(entry.getKey().equals(ElasticsearchUtils.DOCUMENT_META_FIELD_NAME)) {
+                continue;
+            }
             String currentField = (parentField == null) ? entry.getKey() : (String.format("%s.%s", parentField, entry.getKey()));
             if (entry.getValue().has("properties")) {
                 fieldTypeMappings.addAll(generateFieldMappings(currentField, entry.getValue().get("properties")));

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/DocumentTranslator.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/DocumentTranslator.java
@@ -1,0 +1,75 @@
+package com.flipkart.foxtrot.core.querystore;
+
+import com.flipkart.foxtrot.common.Document;
+import com.flipkart.foxtrot.common.DocumentMetadata;
+import com.flipkart.foxtrot.common.Table;
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Created by santanu.s on 24/11/15.
+ */
+public class DocumentTranslator {
+    private static final Logger logger = LoggerFactory.getLogger(DocumentTranslator.class);
+
+    public List<Document> translate(final Table table, final List<Document> inDocuments) {
+        ImmutableList.Builder<Document> docListBuilder = ImmutableList.builder();
+        for(Document document : inDocuments) {
+            docListBuilder.add(translate(table, document));
+        }
+        return docListBuilder.build();
+    }
+
+    public Document translate(final Table table, final Document inDocument) {
+        Document document = new Document();
+        final String rowKey = rowKey(table, inDocument);
+
+        DocumentMetadata metadata = new DocumentMetadata();
+        metadata.setRowKey(rowKey);
+        metadata.setId(inDocument.getId());
+
+        document.setId(rowKey);
+        document.setTimestamp(inDocument.getTimestamp());
+        document.setMetadata(metadata);
+        document.setData(inDocument.getData());
+
+        logger.info("Translated doc row key: {}, {}", rowKey, document);
+        return document;
+    }
+
+    public List<Document> translateBack(final List<Document> inDocuments) {
+        ImmutableList.Builder<Document> listBuilder = ImmutableList.builder();
+        if(null != inDocuments) {
+            for (Document document : inDocuments) {
+                listBuilder.add(translateBack(document));
+            }
+        }
+        return listBuilder.build();
+    }
+
+    public Document translateBack(final Document inDocument) {
+        Document document = new Document();
+        document.setId(inDocument.getMetadata() != null ? inDocument.getMetadata().getId() : inDocument.getId());
+        document.setTimestamp(inDocument.getTimestamp());
+        document.setData(inDocument.getData());
+        return document;
+    }
+
+    public DocumentMetadata metadata(final Table table, final Document inDocument) {
+        final String rowKey = rowKey(table, inDocument);
+
+        DocumentMetadata metadata = new DocumentMetadata();
+        metadata.setRowKey(rowKey);
+        metadata.setId(inDocument.getId());
+
+        logger.info("Doc row key: {}, {}", rowKey, inDocument);
+        return metadata;
+    }
+
+    public String rowKey(final Table table, final Document document) {
+        return String.format("%s:%d:%s", table.getName(), document.getTimestamp(), document.getId());
+    }
+}

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/QueryStore.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/QueryStore.java
@@ -36,6 +36,8 @@ public interface QueryStore {
 
     public List<Document> get(final String table, final List<String> ids) throws QueryStoreException;
 
+    public List<Document> get(final String table, final List<String> ids, boolean bypassMetaLookup) throws QueryStoreException;
+
     public TableFieldMapping getFieldMappings(final String table) throws QueryStoreException;
 
     public void cleanupAll() throws QueryStoreException;

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/FilterAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/FilterAction.java
@@ -92,7 +92,7 @@ public class FilterAction extends Action<Query> {
                         "There is no table called: " + query.getTable());
             }*/
             search = getConnection().getClient().prepareSearch(ElasticsearchUtils.getIndices(parameter.getTable(), parameter))
-                    .setTypes(ElasticsearchUtils.TYPE_NAME)
+                    .setTypes(ElasticsearchUtils.DOCUMENT_TYPE_NAME)
                     .setQuery(new ElasticSearchQueryGenerator(FilterCombinerType.and).genFilter(parameter.getFilters()))
                     .setSearchType(SearchType.QUERY_THEN_FETCH)
                     .setFrom(parameter.getFrom())
@@ -107,7 +107,7 @@ public class FilterAction extends Action<Query> {
             if (ids.isEmpty()) {
                 return new QueryResponse(Collections.<Document>emptyList());
             }
-            return new QueryResponse(getQueryStore().get(parameter.getTable(), ids));
+            return new QueryResponse(getQueryStore().get(parameter.getTable(), ids, true));
         } catch (Exception e) {
             if (null != search) {
                 logger.error("Error running generated query: " + search, e);

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/HistogramAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/HistogramAction.java
@@ -114,7 +114,7 @@ public class HistogramAction extends Action<HistogramRequest> {
             String dateHistogramKey = Utils.sanitizeFieldForAggregation(parameter.getField());
             SearchResponse response = getConnection().getClient().prepareSearch(
                     ElasticsearchUtils.getIndices(parameter.getTable(), parameter))
-                    .setTypes(ElasticsearchUtils.TYPE_NAME)
+                    .setTypes(ElasticsearchUtils.DOCUMENT_TYPE_NAME)
                     .setQuery(new ElasticSearchQueryGenerator(FilterCombinerType.and)
                             .genFilter(parameter.getFilters()))
                     .setSize(0)

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/StatsAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/StatsAction.java
@@ -72,7 +72,7 @@ public class StatsAction extends Action<StatsRequest> {
         try {
             SearchResponse response = getConnection().getClient().prepareSearch(
                     ElasticsearchUtils.getIndices(request.getTable(), request))
-                    .setTypes(ElasticsearchUtils.TYPE_NAME)
+                    .setTypes(ElasticsearchUtils.DOCUMENT_TYPE_NAME)
                     .setQuery(new ElasticSearchQueryGenerator(request.getCombiner()).genFilter(request.getFilters()))
                     .setSize(0)
                     .setSearchType(SearchType.COUNT)

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/StatsTrendAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/StatsTrendAction.java
@@ -85,7 +85,7 @@ public class StatsTrendAction extends Action<StatsTrendRequest> {
             AbstractAggregationBuilder aggregation = buildAggregation(parameter);
             SearchResponse response = getConnection().getClient().prepareSearch(
                     ElasticsearchUtils.getIndices(parameter.getTable(), parameter))
-                    .setTypes(ElasticsearchUtils.TYPE_NAME)
+                    .setTypes(ElasticsearchUtils.DOCUMENT_TYPE_NAME)
                     .setQuery(new ElasticSearchQueryGenerator(parameter.getCombiner()).genFilter(parameter.getFilters()))
                     .setSize(0)
                     .setSearchType(SearchType.COUNT)

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchQueryStore.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchQueryStore.java
@@ -17,29 +17,38 @@ package com.flipkart.foxtrot.core.querystore.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.flipkart.foxtrot.common.Document;
-import com.flipkart.foxtrot.common.FieldTypeMapping;
-import com.flipkart.foxtrot.common.Table;
-import com.flipkart.foxtrot.common.TableFieldMapping;
+import com.flipkart.foxtrot.common.*;
 import com.flipkart.foxtrot.core.datastore.DataStore;
 import com.flipkart.foxtrot.core.datastore.DataStoreException;
 import com.flipkart.foxtrot.core.parsers.ElasticsearchMappingParser;
+import com.flipkart.foxtrot.core.querystore.DocumentTranslator;
 import com.flipkart.foxtrot.core.querystore.QueryStore;
 import com.flipkart.foxtrot.core.querystore.QueryStoreException;
 import com.flipkart.foxtrot.core.querystore.TableMetadataManager;
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.elasticsearch.action.WriteConsistencyLevel;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.status.IndicesStatusResponse;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.hppc.cursors.ObjectCursor;
 import org.elasticsearch.common.joda.time.DateTime;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,17 +89,25 @@ public class ElasticsearchQueryStore implements QueryStore {
             if (new DateTime().plusDays(1).minus(document.getTimestamp()).getMillis() <  0) {
                 return;
             }
-            dataStore.save(tableMetadataManager.get(table), document);
-            long timestamp = document.getTimestamp();
+            final Table tableMeta = tableMetadataManager.get(table);
+            final Document translatedDocuement = dataStore.save(tableMeta, document);
+            long timestamp = translatedDocuement.getTimestamp();
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.start();
             connection.getClient()
-                    .prepareIndex()
-                    .setIndex(ElasticsearchUtils.getCurrentIndex(table, timestamp))
-                    .setType(ElasticsearchUtils.TYPE_NAME)
-                    .setId(document.getId())
-                    .setTimestamp(Long.toString(timestamp))
-                    .setSource(mapper.writeValueAsBytes(document.getData()))
+                    .prepareBulk()
+                    .add(new IndexRequest()
+                            .index(ElasticsearchUtils.getCurrentIndex(table, timestamp))
+                            .type(ElasticsearchUtils.DOCUMENT_TYPE_NAME)
+                            .id(translatedDocuement.getId())
+                            .timestamp(Long.toString(timestamp))
+                            .source(mapper.writeValueAsBytes(translatedDocuement.getData())))
+                    .add(new IndexRequest()
+                            .index(ElasticsearchUtils.getCurrentIndex(table, timestamp))
+                            .type(ElasticsearchUtils.DOCUMENT_META_TYPE_NAME)
+                            .id(translatedDocuement.getId())
+                            .timestamp(Long.toString(timestamp))
+                            .source(mapper.writeValueAsBytes(translatedDocuement.getMetadata())))
                     .setConsistencyLevel(WriteConsistencyLevel.QUORUM)
                     .execute()
                     .get(2, TimeUnit.SECONDS);
@@ -128,12 +145,13 @@ public class ElasticsearchQueryStore implements QueryStore {
                 throw new QueryStoreException(QueryStoreException.ErrorCode.INVALID_REQUEST,
                         "Invalid Document List");
             }
-            dataStore.save(tableMetadataManager.get(table), documents);
+            final Table tableMeta = tableMetadataManager.get(table);
+            final List<Document> translatedDocuments = dataStore.save(tableMeta, documents);
             BulkRequestBuilder bulkRequestBuilder = connection.getClient().prepareBulk();
 
             DateTime dateTime = new DateTime().plusDays(1);
 
-            for (Document document : documents) {
+            for (Document document : translatedDocuments) {
                 long timestamp = document.getTimestamp();
                 if (dateTime.minus(timestamp).getMillis() <  0) {
                     continue;
@@ -141,11 +159,17 @@ public class ElasticsearchQueryStore implements QueryStore {
                 final String index = ElasticsearchUtils.getCurrentIndex(table, timestamp);
                 IndexRequest indexRequest = new IndexRequest()
                         .index(index)
-                        .type(ElasticsearchUtils.TYPE_NAME)
+                        .type(ElasticsearchUtils.DOCUMENT_TYPE_NAME)
                         .id(document.getId())
                         .timestamp(Long.toString(timestamp))
                         .source(mapper.writeValueAsBytes(document.getData()));
                 bulkRequestBuilder.add(indexRequest);
+                IndexRequest metaIndexRequest = new IndexRequest()
+                        .index(index)
+                        .type(ElasticsearchUtils.DOCUMENT_META_TYPE_NAME)
+                        .id(document.getId())
+                        .source(mapper.writeValueAsBytes(document.getMetadata()));
+                bulkRequestBuilder.add(metaIndexRequest);
             }
             if (bulkRequestBuilder.numberOfActions() > 0){
                 Stopwatch stopwatch = new Stopwatch();
@@ -202,8 +226,28 @@ public class ElasticsearchQueryStore implements QueryStore {
             throw new QueryStoreException(QueryStoreException.ErrorCode.DOCUMENT_GET_ERROR,
                     ex.getMessage(), ex);
         }
+        String lookupKey = null;
         try {
-            return dataStore.get(fxTable, id);
+            SearchResponse searchResponse = connection.getClient()
+                    .prepareSearch(ElasticsearchUtils.getIndices(table))
+                    .setTypes(ElasticsearchUtils.DOCUMENT_META_TYPE_NAME)
+                    .setQuery(
+                            QueryBuilders.constantScoreQuery(
+                                    FilterBuilders.boolFilter()
+                                            .must(FilterBuilders.termFilter("id", id))))
+                    .setNoFields()
+                    .setSize(1)
+                    .execute()
+                    .actionGet();
+            if(searchResponse.getHits().totalHits() == 0 ) {
+                logger.warn("Going into compatibility mode, looks using passed in ID as the data store id: {}", id);
+                lookupKey = id;
+            }
+            else {
+                lookupKey = searchResponse.getHits().getHits()[0].getId();
+                logger.debug("Translated lookup key for {} is {}.", id, lookupKey);
+            }
+            return dataStore.get(fxTable, lookupKey);
         } catch (DataStoreException ex) {
             if (ex.getErrorCode().equals(DataStoreException.ErrorCode.STORE_NO_DATA_FOUND_FOR_ID)) {
                 throw new QueryStoreException(QueryStoreException.ErrorCode.DOCUMENT_NOT_FOUND,
@@ -217,13 +261,54 @@ public class ElasticsearchQueryStore implements QueryStore {
 
     @Override
     public List<Document> get(String table, List<String> ids) throws QueryStoreException {
+        return get(table, ids, false);
+    }
+
+    @Override
+    public List<Document> get(String table, List<String> ids, boolean bypassMetalookup) throws QueryStoreException {
         table = ElasticsearchUtils.getValidTableName(table);
         try {
             if (!tableMetadataManager.exists(table)) {
                 throw new QueryStoreException(QueryStoreException.ErrorCode.NO_SUCH_TABLE,
                         "No table exists with the name: " + table);
             }
-            return dataStore.get(tableMetadataManager.get(table), ids);
+            ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings = connection.getClient()
+                    .admin().indices().getMappings(
+                            new GetMappingsRequest()
+                                    .indices(ElasticsearchUtils.getIndices(table))
+                                    .types("metadata"))
+                    .actionGet()
+                    .mappings();
+
+            List<String> rowKeys;
+            if(!bypassMetalookup) {
+                rowKeys = Lists.newArrayList();
+                SearchResponse response = connection.getClient().prepareSearch(ElasticsearchUtils.getIndices(table))
+                        .setQuery(
+                                QueryBuilders.constantScoreQuery(
+                                        FilterBuilders.inFilter("id", ids.toArray(new String[ids.size()]))))
+                        .setFetchSource(false)
+                        .addField("id")
+                        .setSize(ids.size())
+                        .execute()
+                        .actionGet();
+                Set<String> inputKeys = ImmutableSet.copyOf(ids);
+                Set<String> foundKeys = Sets.newHashSet();
+                for (SearchHit hit : response.getHits()) {
+                    rowKeys.add(hit.getId());
+                    foundKeys.add(hit.getFields().get("id").getValue().toString());
+                }
+
+                //Now we've got new keys
+                //Add them all to fetchList
+                //Add old generation keys and invalid keys as is
+                rowKeys.addAll(Sets.difference(inputKeys, foundKeys));
+            }
+            else {
+                rowKeys = ids;
+            }
+            logger.info("Get row keys: {}", rowKeys.size());
+            return dataStore.get(tableMetadataManager.get(table), rowKeys);
         } catch (DataStoreException ex) {
             if (ex.getErrorCode().equals(DataStoreException.ErrorCode.STORE_NO_DATA_FOUND_FOR_IDS)) {
                 throw new QueryStoreException(QueryStoreException.ErrorCode.DOCUMENT_NOT_FOUND,
@@ -252,7 +337,7 @@ public class ElasticsearchQueryStore implements QueryStore {
                     .indices().prepareGetMappings(ElasticsearchUtils.getIndices(table)).execute().actionGet();
 
             for (ObjectCursor<String> index : mappingsResponse.getMappings().keys()) {
-                MappingMetaData mappingData = mappingsResponse.mappings().get(index.value).get(ElasticsearchUtils.TYPE_NAME);
+                MappingMetaData mappingData = mappingsResponse.mappings().get(index.value).get(ElasticsearchUtils.DOCUMENT_TYPE_NAME);
                 mappings.addAll(mappingParser.getFieldMappings(mappingData));
             }
             return new TableFieldMapping(table, mappings);
@@ -325,4 +410,7 @@ public class ElasticsearchQueryStore implements QueryStore {
                     String.format("Unable to delete Indexes - %s", indicesToDelete), ex);
         }
     }
+
+
+
 }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtils.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtils.java
@@ -47,6 +47,9 @@ public class ElasticsearchUtils {
 
     public static final String DOCUMENT_TYPE_NAME = "document";
     public static final String DOCUMENT_META_TYPE_NAME = "metadata";
+    public static final String DOCUMENT_META_FIELD_NAME = "__FOXTROT_METADATA__";
+    public static final String DOCUMENT_META_ID_FIELD_NAME = String.format("%s.id", DOCUMENT_META_FIELD_NAME);
+
     public static final String TABLENAME_PREFIX = "foxtrot";
     public static final String TABLENAME_POSTFIX = "table";
     private static final DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("dd-M-yyyy");
@@ -109,8 +112,9 @@ public class ElasticsearchUtils {
         try {
             PutIndexTemplateRequestBuilder builder = new PutIndexTemplateRequestBuilder(indicesAdminClient, "generic_template");
             builder.setTemplate("foxtrot-*");
+            System.out.println(getDocumentMapping().string());
             builder.addMapping(DOCUMENT_TYPE_NAME, getDocumentMapping());
-            builder.addMapping(DOCUMENT_META_TYPE_NAME, getDocumentMetadataMapping());
+            //builder.addMapping(DOCUMENT_META_TYPE_NAME, getDocumentMetadataMapping());
             return builder.request();
         } catch (IOException ex){
             logger.error("TEMPLATE_CREATION_FAILED", ex);
@@ -175,6 +179,22 @@ public class ElasticsearchUtils {
                             .endObject()
                         .field("dynamic_templates")
                             .startArray()
+                                .startObject()
+                                    .field("template_metadata_fields")
+                                    .startObject()
+                                        .field("path_match", ElasticsearchUtils.DOCUMENT_META_FIELD_NAME + ".*")
+                                        .field("mapping")
+                                        .startObject()
+                                            .field("store", true)
+                                            .field("doc_values", true)
+                                            .field("index", "not_analyzed")
+                                            .field("fielddata")
+                                            .startObject()
+                                                .field("format", "doc_values")
+                                            .endObject()
+                                        .endObject()
+                                    .endObject()
+                                .endObject()
                                 .startObject()
                                     .field("template_timestamp")
                                         .startObject()

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/query/ElasticSearchQueryGenerator.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/query/ElasticSearchQueryGenerator.java
@@ -146,7 +146,7 @@ public class ElasticSearchQueryGenerator extends FilterVisitor {
         for (Filter filter : filters) {
             filter.accept(this);
         }
-        return QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), boolFilterBuilder);
+        return QueryBuilders.constantScoreQuery(boolFilterBuilder);
     }
 
 }

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/MockElasticsearchServer.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/MockElasticsearchServer.java
@@ -17,6 +17,7 @@ package com.flipkart.foxtrot.core;
 
 import org.apache.commons.io.FileUtils;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.node.Node;
@@ -45,6 +46,10 @@ public class MockElasticsearchServer {
                 .local(true)
                 .settings(elasticsearchSettings.build())
                 .node();
+    }
+
+    public void refresh(final String index) {
+        node.client().admin().indices().refresh(new RefreshRequest().indices(index)).actionGet();
     }
 
     public Client getClient() {

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchQueryStoreTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchQueryStoreTest.java
@@ -24,10 +24,12 @@ import com.flipkart.foxtrot.common.TableFieldMapping;
 import com.flipkart.foxtrot.core.MockElasticsearchServer;
 import com.flipkart.foxtrot.core.TestUtils;
 import com.flipkart.foxtrot.core.datastore.DataStore;
+import com.flipkart.foxtrot.core.querystore.DocumentTranslator;
 import com.flipkart.foxtrot.core.querystore.QueryExecutor;
 import com.flipkart.foxtrot.core.querystore.QueryStoreException;
 import com.flipkart.foxtrot.core.querystore.TableMetadataManager;
 import com.flipkart.foxtrot.core.querystore.actions.spi.AnalyticsLoader;
+import com.google.common.collect.ImmutableList;
 import org.elasticsearch.action.get.GetResponse;
 import org.junit.After;
 import org.junit.Before;
@@ -50,6 +52,7 @@ public class ElasticsearchQueryStoreTest {
     private DataStore dataStore;
     private ElasticsearchQueryStore queryStore;
     private ObjectMapper mapper;
+    private TableMetadataManager tableMetadataManager;
 
     @Before
     public void setUp() throws Exception {
@@ -61,7 +64,7 @@ public class ElasticsearchQueryStoreTest {
         ElasticsearchConnection elasticsearchConnection = Mockito.mock(ElasticsearchConnection.class);
         when(elasticsearchConnection.getClient()).thenReturn(elasticsearchServer.getClient());
         ElasticsearchUtils.initializeMappings(elasticsearchConnection.getClient());
-        TableMetadataManager tableMetadataManager = Mockito.mock(TableMetadataManager.class);
+        tableMetadataManager = Mockito.mock(TableMetadataManager.class);
         when(tableMetadataManager.exists(TestUtils.TEST_TABLE_NAME)).thenReturn(true);
         when(tableMetadataManager.get(anyString())).thenReturn(TestUtils.TEST_TABLE);
         AnalyticsLoader analyticsLoader = new AnalyticsLoader(tableMetadataManager, dataStore, queryStore, elasticsearchConnection);
@@ -77,22 +80,22 @@ public class ElasticsearchQueryStoreTest {
 
     @Test
     public void testSaveSingle() throws Exception {
-        Document expectedDocument = new Document();
-        expectedDocument.setId(UUID.randomUUID().toString());
-        expectedDocument.setTimestamp(System.currentTimeMillis());
+        Document originalDocument = new Document();
+        originalDocument.setId(UUID.randomUUID().toString());
+        originalDocument.setTimestamp(System.currentTimeMillis());
         JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
-        expectedDocument.setData(data);
-        queryStore.save(TestUtils.TEST_TABLE_NAME, expectedDocument);
-
+        originalDocument.setData(data);
+        queryStore.save(TestUtils.TEST_TABLE_NAME, originalDocument);
+        final Document translatedDocuemnt = new DocumentTranslator().translate(tableMetadataManager.get(TestUtils.TEST_TABLE_NAME), originalDocument);
         GetResponse getResponse = elasticsearchServer
-                .getClient()
-                .prepareGet(ElasticsearchUtils.getCurrentIndex(TestUtils.TEST_TABLE_NAME, expectedDocument.getTimestamp()),
-                        ElasticsearchUtils.TYPE_NAME,
-                        expectedDocument.getId())
-                .setFields("_timestamp").execute().actionGet();
+                        .getClient()
+                        .prepareGet(ElasticsearchUtils.getCurrentIndex(TestUtils.TEST_TABLE_NAME, originalDocument.getTimestamp()),
+                                ElasticsearchUtils.DOCUMENT_TYPE_NAME,
+                                translatedDocuemnt.getId())
+                        .setFields("_timestamp").execute().actionGet();
         assertTrue("Id should exist in ES", getResponse.isExists());
-        assertEquals("Id should match requestId", expectedDocument.getId(), getResponse.getId());
-        assertEquals("Timestamp should match request timestamp", expectedDocument.getTimestamp(), getResponse.getField("_timestamp").getValue());
+        assertEquals("Id should match requestId", translatedDocuemnt.getId(), getResponse.getId());
+        assertEquals("Timestamp should match request timestamp", translatedDocuemnt.getTimestamp(), getResponse.getField("_timestamp").getValue());
     }
 
     @Test
@@ -119,12 +122,12 @@ public class ElasticsearchQueryStoreTest {
                     mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"))));
         }
         queryStore.save(TestUtils.TEST_TABLE_NAME, documents);
-
-        for (Document document : documents) {
+        final List<Document> translatedDocuemtns = new DocumentTranslator().translate(tableMetadataManager.get(TestUtils.TEST_TABLE_NAME), documents);
+        for (Document document : translatedDocuemtns) {
             GetResponse getResponse = elasticsearchServer
                     .getClient()
                     .prepareGet(ElasticsearchUtils.getCurrentIndex(TestUtils.TEST_TABLE_NAME, document.getTimestamp()),
-                            ElasticsearchUtils.TYPE_NAME,
+                            ElasticsearchUtils.DOCUMENT_TYPE_NAME,
                             document.getId())
                     .setFields("_timestamp").execute().actionGet();
             assertTrue("Id should exist in ES", getResponse.isExists());
@@ -178,8 +181,8 @@ public class ElasticsearchQueryStoreTest {
         JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
         Document document = new Document(id, System.currentTimeMillis(), data);
         document.setTimestamp(timestamp);
-        dataStore.save(TestUtils.TEST_TABLE, document);
-
+        queryStore.save(TestUtils.TEST_TABLE_NAME, document);
+        elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
         Document responseDocument = queryStore.get(TestUtils.TEST_TABLE_NAME, id);
         assertNotNull(responseDocument);
         assertEquals(id, responseDocument.getId());
@@ -208,10 +211,8 @@ public class ElasticsearchQueryStoreTest {
                             mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"))));
             idValues.get(id).setTimestamp(System.currentTimeMillis());
         }
-        for (Document document : idValues.values()) {
-            dataStore.save(TestUtils.TEST_TABLE, document);
-        }
-
+        queryStore.save(TestUtils.TEST_TABLE_NAME, ImmutableList.copyOf(idValues.values()));
+        elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
         List<Document> responseDocuments = queryStore.get(TestUtils.TEST_TABLE_NAME, ids);
         HashMap<String, Document> responseIdValues = new HashMap<String, Document>();
         for (Document doc : responseDocuments) {
@@ -223,6 +224,7 @@ public class ElasticsearchQueryStoreTest {
             assertNotNull(responseIdValues.get(id));
             assertEquals(id, responseIdValues.get(id).getId());
             assertEquals("Timestamp should match request timestamp", idValues.get(id).getTimestamp(), responseIdValues.get(id).getTimestamp());
+            System.out.println("OK: " + id);
         }
     }
 

--- a/foxtrot-server/src/test/java/com/flipkart/foxtrot/server/resources/DocumentResourceTest.java
+++ b/foxtrot-server/src/test/java/com/flipkart/foxtrot/server/resources/DocumentResourceTest.java
@@ -122,6 +122,7 @@ public class DocumentResourceTest extends ResourceTest {
                 System.currentTimeMillis(),
                 factory.objectNode().put("hello", "world"));
         client().resource("/v1/document/" + TestUtils.TEST_TABLE_NAME).type(MediaType.APPLICATION_JSON_TYPE).post(document);
+        elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
         Document response = queryStore.get(TestUtils.TEST_TABLE_NAME, id);
         compare(document, response);
     }
@@ -181,7 +182,7 @@ public class DocumentResourceTest extends ResourceTest {
         documents.add(document1);
         documents.add(document2);
         client().resource(String.format("/v1/document/%s/bulk", TestUtils.TEST_TABLE_NAME)).type(MediaType.APPLICATION_JSON_TYPE).post(documents);
-
+        elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
         compare(document1, queryStore.get(TestUtils.TEST_TABLE_NAME, id1));
         compare(document2, queryStore.get(TestUtils.TEST_TABLE_NAME, id2));
     }
@@ -273,7 +274,7 @@ public class DocumentResourceTest extends ResourceTest {
         String id = UUID.randomUUID().toString();
         Document document = new Document(id, System.currentTimeMillis(), factory.objectNode().put("D", "data"));
         queryStore.save(TestUtils.TEST_TABLE_NAME, document);
-
+        elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
         Document response = client().resource(String.format("/v1/document/%s/%s", TestUtils.TEST_TABLE_NAME, id))
                 .get(Document.class);
         compare(document, response);
@@ -314,6 +315,7 @@ public class DocumentResourceTest extends ResourceTest {
         documents.add(document1);
         documents.add(document2);
         queryStore.save(TestUtils.TEST_TABLE_NAME, documents);
+        elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
         String response = client().resource(String.format("/v1/document/%s", TestUtils.TEST_TABLE_NAME))
                 .queryParam("id", id1)
                 .queryParam("id", id2)


### PR DESCRIPTION
- Meta field added to document
- DocumentTranslator created that translates between low level and high level doc
- HbaseDataStore saves transparently and returns translated document
- Translated doc is saved in es
    - Data part goes as "dcoument" type
    - Metadata part goes as "metadata" type
- Get accepts flag to do search or not
- If flag is set, it searched for provided id's in metadata documents
- FilterAction sets flags false and directly goes through to pull data from HBase
- No other action affected