### PR TITLE
Single quote was missing as outer request was inside single quote. Is…

### DIFF
--- a/scripts/local_es_setup.sh
+++ b/scripts/local_es_setup.sh
@@ -7,7 +7,7 @@ fi
 
 curl -XPUT ${1}:9200/_template/template_foxtrot_mappings -d '
 {
-    "template" : "${2}-*",
+    "template" : "'${2}'-*",
     "settings" : {
         "number_of_shards" : 10,
         "number_of_replicas" : 0


### PR DESCRIPTION
1. fix to #101. 
2. I check mapping and template is getting created but did not notice that $2 variable,  was getting pasted without evaluating variable. 

