### PR TITLE
Metrics aggregation support in group aggregation

### DIFF
--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/group/GroupRequest.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/group/GroupRequest.java
@@ -32,10 +32,11 @@ public class GroupRequest extends ActionRequest {
     @NotEmpty
     private String table;
 
-
     @NotNull
     @NotEmpty
     private List<String> nesting;
+
+    private MetricsAggregation metric;
 
     public GroupRequest() {
     }
@@ -53,8 +54,18 @@ public class GroupRequest extends ActionRequest {
         return nesting;
     }
 
+
     public void setNesting(List<String> nesting) {
         this.nesting = nesting;
+    }
+
+
+    public MetricsAggregation getMetric() {
+        return metric;
+    }
+
+    public void setMetric(MetricsAggregation metric) {
+        this.metric = metric;
     }
 
     @Override
@@ -62,7 +73,7 @@ public class GroupRequest extends ActionRequest {
         return new ToStringBuilder(this)
                 .append("table", table)
                 .append("filters", getFilters())
-                .append("nesting", nesting)
+                .append("nesting", nesting).append("metric", metric)
                 .toString();
     }
 }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/group/MetricsAggregation.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/group/MetricsAggregation.java
@@ -1,0 +1,36 @@
+package com.flipkart.foxtrot.common.group;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Created by swapnil on 08/01/16.
+ */
+public class MetricsAggregation {
+    private MetricsAggragationType type;
+    private String field;
+
+    public MetricsAggragationType getType() {
+        return type;
+    }
+
+    public void setType(MetricsAggragationType type) {
+        this.type = type;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("type", type).append("field",field).toString();
+    }
+
+    public enum MetricsAggragationType {
+        sum,max,min,avg,percentiles,stats
+    }
+}

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/group/MetricsAggregation.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/group/MetricsAggregation.java
@@ -33,4 +33,24 @@ public class MetricsAggregation {
     public enum MetricsAggragationType {
         sum,max,min,avg,percentiles,stats
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MetricsAggregation)) return false;
+
+        MetricsAggregation that = (MetricsAggregation) o;
+
+        if (field != null ? !field.equals(that.field) : that.field != null) return false;
+        if (type != that.type) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type != null ? type.hashCode() : 0;
+        result = 31 * result + (field != null ? field.hashCode() : 0);
+        return result;
+    }
 }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/GroupAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/GroupAction.java
@@ -18,14 +18,15 @@ package com.flipkart.foxtrot.core.querystore.actions;
 import com.flipkart.foxtrot.common.ActionResponse;
 import com.flipkart.foxtrot.common.group.GroupRequest;
 import com.flipkart.foxtrot.common.group.GroupResponse;
+import com.flipkart.foxtrot.common.group.MetricsAggregation;
 import com.flipkart.foxtrot.common.query.Filter;
 import com.flipkart.foxtrot.common.query.FilterCombinerType;
 import com.flipkart.foxtrot.common.query.general.AnyFilter;
 import com.flipkart.foxtrot.core.cache.CacheManager;
 import com.flipkart.foxtrot.core.common.Action;
 import com.flipkart.foxtrot.core.datastore.DataStore;
-import com.flipkart.foxtrot.core.exception.FoxtrotExceptions;
 import com.flipkart.foxtrot.core.exception.FoxtrotException;
+import com.flipkart.foxtrot.core.exception.FoxtrotExceptions;
 import com.flipkart.foxtrot.core.querystore.QueryStore;
 import com.flipkart.foxtrot.core.querystore.actions.spi.AnalyticsProvider;
 import com.flipkart.foxtrot.core.querystore.impl.ElasticsearchConnection;
@@ -38,12 +39,19 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.percentiles.Percentile;
+import org.elasticsearch.search.aggregations.metrics.percentiles.Percentiles;
+import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 
 import java.util.*;
+
+import static com.flipkart.foxtrot.common.group.MetricsAggregation.MetricsAggragationType;
 
 /**
  * User: Santanu Sinha (santanu.sinha@flipkart.com)
@@ -121,6 +129,9 @@ public class GroupAction extends Action<GroupRequest> {
                     rootBuilder = termsBuilder;
                 }
             }
+            if(parameter.getMetric() != null){
+                termsBuilder.subAggregation(getMetricsAggregationBuilder(parameter.getMetric()));
+            }
             query.setQuery(new ElasticSearchQueryGenerator(FilterCombinerType.and)
                     .genFilter(parameter.getFilters()))
                     .setSearchType(SearchType.COUNT)
@@ -129,6 +140,7 @@ public class GroupAction extends Action<GroupRequest> {
             throw FoxtrotExceptions.queryCreationException(parameter, e);
         }
         try {
+
             SearchResponse response = query.execute().actionGet();
             List<String> fields = parameter.getNesting();
             Aggregations aggregations = response.getAggregations();
@@ -136,13 +148,34 @@ public class GroupAction extends Action<GroupRequest> {
             if (aggregations == null) {
                 return new GroupResponse(Collections.<String, Object>emptyMap());
             }
-            return new GroupResponse(getMap(fields, aggregations));
+            return new GroupResponse(getMap(fields, aggregations,parameter.getMetric()));
         } catch (ElasticsearchException e) {
             throw FoxtrotExceptions.createQueryExecutionException(parameter, e);
         }
     }
 
-    private Map<String, Object> getMap(List<String> fields, Aggregations aggregations) {
+    private AbstractAggregationBuilder getMetricsAggregationBuilder(MetricsAggregation metricsAggregation) {
+        MetricsAggragationType type = metricsAggregation.getType();
+        String field = metricsAggregation.getField();
+        switch (type){
+            case sum:
+                return AggregationBuilders.sum(Utils.sanitizeFieldForAggregation(type.name())).field(field);
+            case min:
+                return AggregationBuilders.min(Utils.sanitizeFieldForAggregation(type.name())).field(field);
+            case max:
+                return AggregationBuilders.max(Utils.sanitizeFieldForAggregation(type.name())).field(field);
+            case avg:
+                return AggregationBuilders.avg(Utils.sanitizeFieldForAggregation(type.name())).field(field);
+            case stats:
+                return AggregationBuilders.stats(Utils.sanitizeFieldForAggregation(type.name())).field(field);
+            case percentiles:
+                return AggregationBuilders.percentiles(Utils.sanitizeFieldForAggregation(type.name())).field(field);
+            default:
+                return null;
+        }
+    }
+
+    private Map<String, Object> getMap(List<String> fields, Aggregations aggregations, MetricsAggregation metricsAggregation) {
         final String field = fields.get(0);
         final List<String> remainingFields = (fields.size() > 1) ? fields.subList(1, fields.size())
                 : new ArrayList<>();
@@ -150,13 +183,67 @@ public class GroupAction extends Action<GroupRequest> {
         Map<String, Object> levelCount = Maps.newHashMap();
         for (Terms.Bucket bucket : terms.getBuckets()) {
             if (fields.size() == 1) {
-                levelCount.put(bucket.getKey(), bucket.getDocCount());
+                if(metricsAggregation != null){
+                    levelCount.put(bucket.getKey(), getMetricsAggregationMap(bucket.getDocCount(), bucket.getAggregations(), metricsAggregation));
+                }else{
+                    levelCount.put(bucket.getKey(), bucket.getDocCount());
+                }
             } else {
-                levelCount.put(bucket.getKey(), getMap(remainingFields, bucket.getAggregations()));
+                levelCount.put(bucket.getKey(), getMap(remainingFields, bucket.getAggregations(),metricsAggregation));
             }
         }
         return levelCount;
 
+    }
+
+    private Map<String, Object> getMetricsAggregationMap(long docCount, Aggregations aggregations, MetricsAggregation metricAggrigation) {
+        Map<String,Object> parentMap = Maps.newHashMap();
+        parentMap.put("count",docCount);
+        MetricsAggragationType type = metricAggrigation.getType();
+
+        Map<String,Object> statsMap = Maps.newHashMap();
+        parentMap.put(type.name(),statsMap);
+
+        switch (type){
+            case sum:
+            case min:
+            case max:
+            case avg:
+                NumericMetricsAggregation.SingleValue sum = aggregations.get(type.name());
+                statsMap.put("value",sum.value());
+                break;
+            case stats:
+                Stats stats = aggregations.get(type.name());
+                statsMap.put("value", getStatsCountMap(stats));
+                break;
+            case percentiles:
+                Percentiles percentiles = aggregations.get(type.name());
+                statsMap.put("value",getPercentileMap(percentiles));
+                break;
+        }
+
+
+        return parentMap;
+    }
+
+    private Map<Double,Double> getPercentileMap(Percentiles percentiles) {
+        Map<Double,Double> statsMap = Maps.newHashMap();
+        Iterator<Percentile> iterator = percentiles.iterator();
+        while (iterator.hasNext()){
+            Percentile percentile = iterator.next();
+            statsMap.put(percentile.getPercent(),percentile.getValue());
+        }
+        return statsMap;
+    }
+
+    private Map<String,Object> getStatsCountMap(Stats stats) {
+        Map<String,Object> statsMap = Maps.newHashMap();
+        statsMap.put("count",stats.getCount());
+        statsMap.put("min",stats.getMin());
+        statsMap.put("max",stats.getMax());
+        statsMap.put("avg",stats.getAvg());
+        statsMap.put("sum",stats.getSum());
+        return statsMap;
     }
 
 }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/GroupAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/GroupAction.java
@@ -83,6 +83,10 @@ public class GroupAction extends Action<GroupRequest> {
         for (int i = 0; i < query.getNesting().size(); i++) {
             filterHashKey += 31 * query.getNesting().get(i).hashCode() * (i + 1);
         }
+
+        if(query.getMetric() != null){
+            filterHashKey += 31 * query.getMetric().hashCode();
+        }
         return String.format("%s-%d", query.getTable(), filterHashKey);
     }
 

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/actions/GroupActionTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/actions/GroupActionTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.flipkart.foxtrot.common.Document;
 import com.flipkart.foxtrot.common.group.GroupRequest;
 import com.flipkart.foxtrot.common.group.GroupResponse;
+import com.flipkart.foxtrot.common.group.MetricsAggregation;
 import com.flipkart.foxtrot.common.query.Filter;
 import com.flipkart.foxtrot.common.query.general.EqualsFilter;
 import com.flipkart.foxtrot.common.query.numeric.GreaterThanFilter;
@@ -30,6 +31,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.text.DecimalFormat;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
@@ -276,5 +278,134 @@ public class GroupActionTest extends ActionTest {
 
         GroupResponse actualResult = GroupResponse.class.cast(getQueryExecutor().execute(groupRequest));
         assertEquals(response, actualResult.getResult());
+    }
+
+    @Test
+      public void testGroupActionWithMetricsSum() throws FoxtrotException {
+        GroupRequest groupRequest = new GroupRequest();
+        groupRequest.setTable(TestUtils.TEST_TABLE_NAME);
+        groupRequest.setNesting(Arrays.asList("os"));
+
+        MetricsAggregation metricsAggregation = new MetricsAggregation();
+        metricsAggregation.setField("battery");
+        metricsAggregation.setType(MetricsAggregation.MetricsAggragationType.sum);
+        groupRequest.setMetric(metricsAggregation);
+
+        GroupResponse actualResult = GroupResponse.class.cast(getQueryExecutor().execute(groupRequest));
+        assertEquals(7l, ((Map<String,Objects>)actualResult.getResult().get("android")).get("count"));
+        assertEquals(4l, ((Map<String,Objects>)actualResult.getResult().get("ios")).get("count"));
+        assertEquals(486.0, ((Map<String,Map<String,Object>>)actualResult.getResult().get("android")).get("sum").get("value"));
+        assertEquals(159.0, ((Map<String,Map<String,Object>>)actualResult.getResult().get("ios")).get("sum").get("value"));
+    }
+    @Test
+     public void testGroupActionWithMetricsMax() throws FoxtrotException {
+        GroupRequest groupRequest = new GroupRequest();
+        groupRequest.setTable(TestUtils.TEST_TABLE_NAME);
+        groupRequest.setNesting(Arrays.asList("os"));
+
+        MetricsAggregation metricsAggregation = new MetricsAggregation();
+        metricsAggregation.setField("battery");
+        metricsAggregation.setType(MetricsAggregation.MetricsAggragationType.max);
+        groupRequest.setMetric(metricsAggregation);
+
+        GroupResponse actualResult = GroupResponse.class.cast(getQueryExecutor().execute(groupRequest));
+        assertEquals(7l, ((Map<String,Objects>)actualResult.getResult().get("android")).get("count"));
+        assertEquals(4l, ((Map<String,Objects>)actualResult.getResult().get("ios")).get("count"));
+        assertEquals(99.0, ((Map<String,Map<String,Object>>)actualResult.getResult().get("android")).get("max").get("value"));
+        assertEquals(56.0, ((Map<String,Map<String,Object>>)actualResult.getResult().get("ios")).get("max").get("value"));
+    }
+
+    @Test
+    public void testGroupActionWithMetricsMin() throws FoxtrotException {
+        GroupRequest groupRequest = new GroupRequest();
+        groupRequest.setTable(TestUtils.TEST_TABLE_NAME);
+        groupRequest.setNesting(Arrays.asList("os"));
+
+        MetricsAggregation metricsAggregation = new MetricsAggregation();
+        metricsAggregation.setField("battery");
+        metricsAggregation.setType(MetricsAggregation.MetricsAggragationType.min);
+        groupRequest.setMetric(metricsAggregation);
+
+        GroupResponse actualResult = GroupResponse.class.cast(getQueryExecutor().execute(groupRequest));
+        assertEquals(7l, ((Map<String,Objects>)actualResult.getResult().get("android")).get("count"));
+        assertEquals(4l, ((Map<String,Objects>)actualResult.getResult().get("ios")).get("count"));
+        assertEquals(24.0, ((Map<String,Map<String,Object>>)actualResult.getResult().get("android")).get("min").get("value"));
+        assertEquals(24.0, ((Map<String,Map<String,Object>>)actualResult.getResult().get("ios")).get("min").get("value"));
+    }
+
+    @Test
+    public void testGroupActionWithMetricsAvg() throws FoxtrotException {
+        GroupRequest groupRequest = new GroupRequest();
+        groupRequest.setTable(TestUtils.TEST_TABLE_NAME);
+        groupRequest.setNesting(Arrays.asList("os"));
+
+        MetricsAggregation metricsAggregation = new MetricsAggregation();
+        metricsAggregation.setField("battery");
+        metricsAggregation.setType(MetricsAggregation.MetricsAggragationType.avg);
+        groupRequest.setMetric(metricsAggregation);
+
+        GroupResponse actualResult = GroupResponse.class.cast(getQueryExecutor().execute(groupRequest));
+        assertEquals(7l, ((Map<String,Objects>)actualResult.getResult().get("android")).get("count"));
+        assertEquals(4l, ((Map<String,Objects>)actualResult.getResult().get("ios")).get("count"));
+        Double actualAnd = (Double) ((Map<String, Map<String, Object>>) actualResult.getResult().get("android")).get("avg").get("value");
+        assertEquals("69.43", new DecimalFormat("#.00").format(actualAnd));
+        Double actualIos = (Double) ((Map<String, Map<String, Object>>) actualResult.getResult().get("ios")).get("avg").get("value");
+        assertEquals("39.75", new DecimalFormat("#.00").format(actualIos));
+    }
+
+    @Test
+    public void testGroupActionWithMetricsStats() throws FoxtrotException {
+        GroupRequest groupRequest = new GroupRequest();
+        groupRequest.setTable(TestUtils.TEST_TABLE_NAME);
+        groupRequest.setNesting(Arrays.asList("os"));
+
+        MetricsAggregation metricsAggregation = new MetricsAggregation();
+        metricsAggregation.setField("battery");
+        metricsAggregation.setType(MetricsAggregation.MetricsAggragationType.stats);
+        groupRequest.setMetric(metricsAggregation);
+
+        GroupResponse actualResult = GroupResponse.class.cast(getQueryExecutor().execute(groupRequest));
+        assertEquals(7l, ((Map<String,Objects>)actualResult.getResult().get("android")).get("count"));
+        assertEquals(4l, ((Map<String,Objects>)actualResult.getResult().get("ios")).get("count"));
+        Map<String,Double> actualAnd = (Map<String, Double>) ((Map<String, Map<String, Object>>) actualResult.getResult().get("android")).get("stats").get("value");
+        assertEquals("69.43", new DecimalFormat("#.00").format(actualAnd.get("avg")));
+        assertEquals("24.00", new DecimalFormat("#.00").format(actualAnd.get("min")));
+        assertEquals("486.00", new DecimalFormat("#.00").format(actualAnd.get("sum")));
+
+
+        Map<String,Double> actualIos = (Map<String, Double>) ((Map<String, Map<String, Object>>) actualResult.getResult().get("ios")).get("stats").get("value");
+        assertEquals("39.75", new DecimalFormat("#.00").format(actualIos.get("avg")));
+        assertEquals("24.00", new DecimalFormat("#.00").format(actualIos.get("min")));
+        assertEquals("159.00", new DecimalFormat("#.00").format(actualIos.get("sum")));
+    }
+
+    @Test
+    public void testGroupActionWithMetricsPercentiles() throws FoxtrotException {
+        GroupRequest groupRequest = new GroupRequest();
+        groupRequest.setTable(TestUtils.TEST_TABLE_NAME);
+        groupRequest.setNesting(Arrays.asList("os"));
+
+        MetricsAggregation metricsAggregation = new MetricsAggregation();
+        metricsAggregation.setField("battery");
+        metricsAggregation.setType(MetricsAggregation.MetricsAggragationType.percentiles);
+        groupRequest.setMetric(metricsAggregation);
+
+        GroupResponse actualResult = GroupResponse.class.cast(getQueryExecutor().execute(groupRequest));
+        assertEquals(7l, ((Map<String,Objects>)actualResult.getResult().get("android")).get("count"));
+        assertEquals(4l, ((Map<String,Objects>)actualResult.getResult().get("ios")).get("count"));
+        Map<Double,Double> actualAnd = (Map<Double, Double>) ((Map<String, Map<String, Object>>) actualResult.getResult().get("android")).get("percentiles").get("value");
+        Map<String,Double> actualIos = (Map<String, Double>) ((Map<String, Map<String, Object>>) actualResult.getResult().get("ios")).get("percentiles").get("value");
+
+        assertEquals("25.44", new DecimalFormat("#.00").format(actualAnd.get(1.0)));
+        assertEquals("31.20", new DecimalFormat("#.00").format(actualAnd.get(5.0)));
+        assertEquals("61.00", new DecimalFormat("#.00").format(actualAnd.get(25.0)));
+        assertEquals("76.00", new DecimalFormat("#.00").format(actualAnd.get(50.0)));
+        assertEquals("82.50", new DecimalFormat("#.00").format(actualAnd.get(75.0)));
+
+        assertEquals("24.33", new DecimalFormat("#.00").format(actualIos.get(1.0)));
+        assertEquals("25.65", new DecimalFormat("#.00").format(actualIos.get(5.0)));
+        assertEquals("32.25", new DecimalFormat("#.00").format(actualIos.get(25.0)));
+        assertEquals("39.50", new DecimalFormat("#.00").format(actualIos.get(50.0)));
+        assertEquals("47.00", new DecimalFormat("#.00").format(actualIos.get(75.0)));
     }
 }


### PR DESCRIPTION
#109

This pull request will enable user to use group aggregation analytics api to return metrics aggregation as innermost aggregation for field specified by user. 

Supported metrics aggregations are : avg, min , max, sum, stats, percentiles. 

Eg input :-
 {
    "opcode": "group",
    "table": "order_status",
  "filters": [
    ],
  "metric":{
    "type":"sum",
    "field":"amount"
  },
  "nesting": [
        "hub_id",
    "agent_id"
    ]
}


sample output :- 

{
    "opcode": "group",
    "result": {
        "1": {
            "1": {
                "count": 1,
                "sum": {
                    "value": 100
                }
            },
            "2": {
                "count": 2,
                "sum": {
                    "value": 250
                }
            },
            "3": {
                "count": 3,
                "sum": {
                    "value": 350
                }
            }
        },
        "2": {
            "7": {
                "count": 2,
                "sum": {
                    "value": 200
                }
            },
            "8": {
                "count": 1,
                "sum": {
                    "value": 150
                }
            }
        }
    }
}

 
