### PR TITLE
Removed hardcoded IP address

### DIFF
--- a/config/docker.yml
+++ b/config/docker.yml
@@ -5,14 +5,14 @@ http:
 
 elasticsearch:
   hosts:
-  - 192.168.99.100
+  - elasticsearch
   cluster: elasticsearch
   tableNamePrefix: foxtrot 
 
 hbase:
   secure : false
   tableName: foxtrot
-  hbaseZookeeperQuorum: 192.168.99.100
+  hbaseZookeeperQuorum: hbase
   hbaseZookeeperClientPort: 2181
 
 cluster:


### PR DESCRIPTION
 Removed Docker-machine ip from docker file and using hostname mentioned in docker-compose. Docker-machine was used only for mac not required for other linux os.