### PR TITLE
Methods should not be empty:

### DIFF
--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/common/PeriodSelector.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/common/PeriodSelector.java
@@ -93,17 +93,17 @@ public class PeriodSelector extends FilterVisitor {
 
     @Override
     public void visit(AnyFilter anyFilter) throws Exception {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(InFilter inFilter) throws Exception {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(ExistsFilter existsFilter) throws Exception {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/DistributedTableMetadataManager.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/DistributedTableMetadataManager.java
@@ -107,5 +107,6 @@ public class DistributedTableMetadataManager implements TableMetadataManager {
 
     @Override
     public void stop() throws Exception {
+        throw new UnsupportedOperationException();
     }
 }

--- a/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/util/ManagedActionScanner.java
+++ b/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/util/ManagedActionScanner.java
@@ -85,7 +85,7 @@ public class ManagedActionScanner implements Managed {
 
     @Override
     public void stop() throws Exception {
-
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/SqlElementVisitor.java
+++ b/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/SqlElementVisitor.java
@@ -77,321 +77,321 @@ public class SqlElementVisitor implements StatementVisitor, SelectVisitor, FromI
 
     @Override
     public void visit(TimestampValue timestampValue) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Parenthesis parenthesis) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(StringValue stringValue) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Addition addition) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Division division) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Multiplication multiplication) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Subtraction subtraction) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(AndExpression andExpression) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(OrExpression orExpression) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Between between) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(EqualsTo equalsTo) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(GreaterThan greaterThan) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(GreaterThanEquals greaterThanEquals) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(InExpression inExpression) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(IsNullExpression isNullExpression) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(LikeExpression likeExpression) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(MinorThan minorThan) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(MinorThanEquals minorThanEquals) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(NotEqualsTo notEqualsTo) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Column tableColumn) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(CaseExpression caseExpression) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(WhenClause whenClause) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(ExistsExpression existsExpression) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(AllComparisonExpression allComparisonExpression) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(AnyComparisonExpression anyComparisonExpression) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Concat concat) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Matches matches) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(BitwiseAnd bitwiseAnd) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(BitwiseOr bitwiseOr) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(BitwiseXor bitwiseXor) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(CastExpression cast) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Modulo modulo) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(AnalyticExpression aexpr) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(ExtractExpression eexpr) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(IntervalExpression iexpr) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(OracleHierarchicalExpression oexpr) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(RegExpMatchOperator rexpr) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Table tableName) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(SubSelect subSelect) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(ExpressionList expressionList) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(MultiExpressionList multiExprList) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(SubJoin subjoin) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(LateralSubSelect lateralSubSelect) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(ValuesList valuesList) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(AllColumns allColumns) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(AllTableColumns allTableColumns) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(SelectExpressionItem selectExpressionItem) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(PlainSelect plainSelect) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(SetOperationList setOpList) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(WithItem withItem) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Select select) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Delete delete) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Update update) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Insert insert) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Replace replace) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Drop drop) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Truncate truncate) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(CreateIndex createIndex) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(CreateTable createTable) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(CreateView createView) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Alter alter) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Statements stmts) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(Describe describe) {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void visit(ShowTables showTables) {
-
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1186 Methods should not be empty:

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1186

Please let me know if you have any questions.

Zeeshan Asghar