### PR TITLE
Private methods that don't access instance data should be static

### DIFF
--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/parsers/ElasticsearchMappingParser.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/parsers/ElasticsearchMappingParser.java
@@ -59,7 +59,7 @@ public class ElasticsearchMappingParser {
         return fieldTypeMappings;
     }
 
-    private FieldType getFieldType(JsonNode jsonNode) {
+    private static FieldType getFieldType(JsonNode jsonNode) {
         String type = jsonNode.asText();
         return FieldType.valueOf(type.toUpperCase());
     }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/DistinctAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/DistinctAction.java
@@ -147,7 +147,7 @@ public class DistinctAction extends Action<DistinctRequest> {
         }
     }
 
-    private String getProperKey(String parentKey, String currentKey) {
+    private static String getProperKey(String parentKey, String currentKey) {
         return parentKey == null ? currentKey : parentKey + Constants.SEPARATOR + currentKey;
     }
 

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/GroupAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/GroupAction.java
@@ -128,7 +128,7 @@ public class GroupAction extends Action<GroupRequest> {
         }
     }
 
-    private Map<String, Object> getMap(List<String> fields, Aggregations aggregations) {
+    private static Map<String, Object> getMap(List<String> fields, Aggregations aggregations) {
         final String field = fields.get(0);
         final List<String> remainingFields = (fields.size() > 1) ? fields.subList(1, fields.size())
                 : new ArrayList<String>();

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/TrendAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/TrendAction.java
@@ -169,7 +169,7 @@ public class TrendAction extends Action<TrendRequest> {
                 .subAggregation(Utils.buildDateHistogramAggregation(request.getTimestamp(), interval));
     }
 
-    private TrendResponse buildResponse(TrendRequest request, Aggregations aggregations){
+    private static TrendResponse buildResponse(TrendRequest request, Aggregations aggregations){
         String field = request.getField();
         Map<String, List<TrendResponse.Count>> trendCounts = new TreeMap<String, List<TrendResponse.Count>>();
         Terms terms = aggregations.get(Utils.sanitizeFieldForAggregation(field));

--- a/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/InitializerCommand.java
+++ b/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/InitializerCommand.java
@@ -78,7 +78,7 @@ public class InitializerCommand extends ConfiguredCommand<FoxtrotServerConfigura
 
     }
 
-    private void createMetaIndex(final ElasticsearchConnection connection,
+    private static void createMetaIndex(final ElasticsearchConnection connection,
                                  final String indexName,
                                  int replicaCount) throws Exception {
         try {

--- a/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/resources/AsyncResource.java
+++ b/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/resources/AsyncResource.java
@@ -48,7 +48,7 @@ public class AsyncResource {
         return Response.ok(getData(dataToken)).build();
     }
 
-    private ActionResponse getData(final AsyncDataToken dataToken) {
+    private static ActionResponse getData(final AsyncDataToken dataToken) {
         try {
             return CacheUtils.getCacheFor(dataToken.getAction()).get(dataToken.getKey());
         } catch (Exception e) {

--- a/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/QueryTranslator.java
+++ b/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/QueryTranslator.java
@@ -315,7 +315,7 @@ public class QueryTranslator extends SqlElementVisitor {
             }
         }
 
-        private FqlQueryType getType(String function) {
+        private static FqlQueryType getType(String function) {
             if(function.equalsIgnoreCase("trend")) {
                 return FqlQueryType.trend;
             }
@@ -334,7 +334,7 @@ public class QueryTranslator extends SqlElementVisitor {
             return FqlQueryType.select;
         }
 
-        private TrendRequest parseTrendFunction(List expressions) {
+        private static TrendRequest parseTrendFunction(List expressions) {
             if(expressions == null || expressions.isEmpty() || expressions.size() > 3) {
                 throw new RuntimeException("trend function has following format: trend(fieldname, [period, [timestamp field]])");
             }
@@ -349,7 +349,7 @@ public class QueryTranslator extends SqlElementVisitor {
             return trendRequest;
         }
 
-        private StatsTrendRequest parseStatsTrendFunction(List expressions) {
+        private static StatsTrendRequest parseStatsTrendFunction(List expressions) {
             if(expressions == null || expressions.isEmpty() || expressions.size() > 2) {
                 throw new RuntimeException("statstrend function has following format: statstrend(fieldname, [period])");
             }
@@ -361,7 +361,7 @@ public class QueryTranslator extends SqlElementVisitor {
             return statsTrendRequest;
         }
 
-        private StatsRequest parseStatsFunction(List expressions) {
+        private static StatsRequest parseStatsFunction(List expressions) {
             if(expressions == null || expressions.isEmpty() || expressions.size() > 1) {
                 throw new RuntimeException("stats function has following format: stats(fieldname)");
             }
@@ -370,7 +370,7 @@ public class QueryTranslator extends SqlElementVisitor {
             return statsRequest;
         }
 
-        private HistogramRequest parseHistogramRequest(ExpressionList expressionList) {
+        private static HistogramRequest parseHistogramRequest(ExpressionList expressionList) {
             if(expressionList != null && (expressionList.getExpressions() != null && expressionList.getExpressions().size() > 2)) {
                 throw new RuntimeException("histogram function has the following format: histogram([period, [timestamp field]])");
             }
@@ -406,7 +406,7 @@ public class QueryTranslator extends SqlElementVisitor {
             throw new RuntimeException("count function has the following format: count([distinct] */column_name)");
         }
 
-        private String expressionToString(Expression expression) {
+        private static String expressionToString(Expression expression) {
             if(expression instanceof Column) {
                 return ((Column)expression).getFullyQualifiedName();
             }
@@ -550,7 +550,7 @@ public class QueryTranslator extends SqlElementVisitor {
         }
 
 
-        private LastFilter parseWindowFunction(List expressions) {
+        private static LastFilter parseWindowFunction(List expressions) {
             if(expressions == null || expressions.isEmpty() || expressions.size() > 3) {
                 throw new RuntimeException("last function has following format: last(duration, [start-time, [timestamp field]])");
             }
@@ -572,7 +572,7 @@ public class QueryTranslator extends SqlElementVisitor {
             return getNumbericValue(expression);
         }
 
-        private Number getNumbericValue(Expression expression) {
+        private static Number getNumbericValue(Expression expression) {
             if(expression instanceof DoubleValue) {
                 return ((DoubleValue)expression).getValue();
             }

--- a/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/responseprocessors/Flattener.java
+++ b/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/responseprocessors/Flattener.java
@@ -237,7 +237,7 @@ public class Flattener implements ResponseVisitor {
         return flatRepresentation;
     }
 
-    private int lengthMax(int currMax, final String rhs) {
+    private static int lengthMax(int currMax, final String rhs) {
         return currMax > rhs.length() ? currMax : rhs.length();
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2325 private methods that don't access instance data should be static

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2325

Please let me know if you have any questions.

Zeeshan Asghar