### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/common/CacheUtils.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/common/CacheUtils.java
@@ -24,7 +24,11 @@ import java.util.Map;
  * Time: 5:20 PM
  */
 public class CacheUtils {
-
+    
+    private CacheUtils() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     private static final Map<String, Cache> cacheMap = new HashMap<String, Cache>();
 
     private static CacheFactory cacheFactory = null;

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/impl/hbase/HBaseUtil.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/impl/hbase/HBaseUtil.java
@@ -32,6 +32,10 @@ import java.io.IOException;
 public abstract class HBaseUtil {
     private static final Logger logger = LoggerFactory.getLogger(HBaseUtil.class);
 
+    private HBaseUtil() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     public static Configuration create(final HbaseConfig hbaseConfig) throws IOException {
         Configuration configuration = HBaseConfiguration.create();
 

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/Constants.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/Constants.java
@@ -22,4 +22,8 @@ public class Constants {
     public static final String FIELD_REPLACEMENT_REGEX = "[^a-zA-Z0-9\\-_]";
     public static final String FIELD_REPLACEMENT_VALUE = "_";
     public static final String SEPARATOR = "_--&--_";
+    
+    private Constants() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
 }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/Utils.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/Utils.java
@@ -9,6 +9,10 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram;
  */
 public class Utils {
 
+    private Utils() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     public static AbstractAggregationBuilder buildExtendedStatsAggregation(String field) {
         String metricKey = getExtendedStatsAggregationKey(field);
         return AggregationBuilders.extendedStats(metricKey).field(field);

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtils.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtils.java
@@ -52,6 +52,10 @@ public class ElasticsearchUtils {
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormat.forPattern("dd-M-yyyy");
     private static ObjectMapper mapper;
 
+    private ElasticsearchUtils() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     public static void setMapper(ObjectMapper mapper) {
         ElasticsearchUtils.mapper = mapper;
     }

--- a/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/providers/FlatToCsvConverter.java
+++ b/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/providers/FlatToCsvConverter.java
@@ -10,6 +10,11 @@ import java.util.List;
 import java.util.Map;
 
 public class FlatToCsvConverter {
+    
+    private FlatToCsvConverter() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     public static void convert(final FlatRepresentation representation, Writer writer) throws IOException {
         CSVWriter data = new CSVWriter(writer);
         List<FieldHeader> headers = representation.getHeaders();

--- a/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/providers/FoxtrotExtraMediaType.java
+++ b/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/providers/FoxtrotExtraMediaType.java
@@ -2,4 +2,8 @@ package com.flipkart.foxtrot.server.providers;
 
 public class FoxtrotExtraMediaType {
     public static final String TEXT_CSV = "text/csv";
+    
+    private FoxtrotExtraMediaType() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
 }

--- a/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/Constants.java
+++ b/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/Constants.java
@@ -6,4 +6,9 @@ package com.flipkart.foxtrot.sql;
 public class Constants {
     public static final String SQL_TABLE_REGEX = "[^a-zA-Z0-9\\-_]";
     public static final String SQL_FIELD_REGEX = "[^a-zA-Z0-9.\\-_]";
+    
+    private Constants() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
 }

--- a/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/responseprocessors/FlatteningUtils.java
+++ b/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/responseprocessors/FlatteningUtils.java
@@ -12,6 +12,10 @@ import java.util.*;
 public class FlatteningUtils {
     private static final String DEFAULT_SEPARATOR = ".";
 
+    private FlatteningUtils() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     public static FlatRepresentation genericParse(JsonNode response) {
         List<FieldHeader> headers = Lists.newArrayList();
         Map<String, MetaData> docFields = generateFieldMappings(null, response);

--- a/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/util/QueryUtils.java
+++ b/foxtrot-sql/src/main/java/com/flipkart/foxtrot/sql/util/QueryUtils.java
@@ -7,6 +7,11 @@ import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.schema.Column;
 
 public class QueryUtils {
+    
+    private QueryUtils() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     public static String expressionToString(Expression expression) {
         if(expression instanceof Column) {
             return ((Column)expression).getFullyQualifiedName();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1118  Utility classes should not have public constructors

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118 

Please let me know if you have any questions.

Zeeshan Asghar