### PR TITLE
The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/QueryStoreException.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/QueryStoreException.java
@@ -21,6 +21,9 @@ package com.flipkart.foxtrot.core.querystore;
  * Time: 9:18 PM
  */
 public class QueryStoreException extends Exception {
+    
+    private final ErrorCode errorCode;
+    
     public QueryStoreException(ErrorCode errorCode, String message) {
         super(message);
         this.errorCode = errorCode;
@@ -48,8 +51,6 @@ public class QueryStoreException extends Exception {
         DATA_CLEANUP_ERROR
 
     }
-
-    private final ErrorCode errorCode;
 
     public ErrorCode getErrorCode() {
         return errorCode;

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/DistributedCache.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/DistributedCache.java
@@ -40,6 +40,11 @@ public class DistributedCache implements Cache {
     private final IMap<String, String> distributedMap;
     private final ObjectMapper mapper;
 
+    public DistributedCache(HazelcastConnection hazelcastConnection, String name, ObjectMapper mapper) {
+        this.distributedMap = hazelcastConnection.getHazelcast().getMap(NAME_PREFIX + name);
+        this.mapper = mapper;
+    }
+    
     public static void setupConfig(HazelcastConnection hazelcastConnection) {
         MapConfig mapConfig = hazelcastConnection.getHazelcastConfig().getMapConfig(NAME_PREFIX + "*");
         mapConfig.setInMemoryFormat(InMemoryFormat.BINARY);
@@ -51,11 +56,6 @@ public class DistributedCache implements Cache {
         nearCacheConfig.setInvalidateOnChange(true);
         nearCacheConfig.setMaxIdleSeconds(10);
         mapConfig.setNearCacheConfig(nearCacheConfig);
-    }
-
-    public DistributedCache(HazelcastConnection hazelcastConnection, String name, ObjectMapper mapper) {
-        this.distributedMap = hazelcastConnection.getHazelcast().getMap(NAME_PREFIX + name);
-        this.mapper = mapper;
     }
 
     @Override

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/TableMapStore.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/TableMapStore.java
@@ -48,7 +48,16 @@ public class TableMapStore implements MapStore<String, Table> {
 
     public static final String TABLE_META_INDEX = "table-meta";
     public static final String TABLE_META_TYPE = "table-meta";
+    private final ElasticsearchConnection elasticsearchConnection;
+    private final ObjectMapper objectMapper;
 
+    public TableMapStore(ElasticsearchConnection elasticsearchConnection) {
+        this.elasticsearchConnection = elasticsearchConnection;
+        this.objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+    }
+    
     public static class Factory implements MapStoreFactory<String, Table> {
         private final ElasticsearchConnection elasticsearchConnection;
 
@@ -64,16 +73,6 @@ public class TableMapStore implements MapStore<String, Table> {
 
     public static Factory factory(ElasticsearchConnection elasticsearchConnection) {
         return new Factory(elasticsearchConnection);
-    }
-
-    private final ElasticsearchConnection elasticsearchConnection;
-    private final ObjectMapper objectMapper;
-
-    public TableMapStore(ElasticsearchConnection elasticsearchConnection) {
-        this.elasticsearchConnection = elasticsearchConnection;
-        this.objectMapper = new ObjectMapper();
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1213  The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213 

Please let me know if you have any questions.

Zeeshan Asghar