### PR TITLE
Marathon cluster discovery support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN \
 
 EXPOSE 17000
 EXPOSE 17001
+EXPOSE 5701
 
 VOLUME /var/log/foxtrot-server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Swapnil Marghade <s.g.marghade [at] gmail.com>
 
 
 RUN \
-  apt-get install -y --no-install-recommends software-properties-common \
+  apt-get clean && apt-get update && apt-get install -y --no-install-recommends software-properties-common \
   && add-apt-repository ppa:webupd8team/java \
   && gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \
   && apt-get update \

--- a/config/docker.yml
+++ b/config/docker.yml
@@ -20,8 +20,10 @@ hbase:
 
 cluster:
   name: foxtrot
-  disableMulticast: true
-  members: ["localhost:5701", "localhost:5702"]
+  discovery:
+    type: foxtrot_simple
+    disableMulticast: true
+    members: ["localhost:5701"]
 
 logging:
   level: INFO

--- a/config/local.yml
+++ b/config/local.yml
@@ -20,8 +20,10 @@ hbase:
 
 cluster:
   name: foxtrot
-  disableMulticast: true
-  members: ["localhost:5701"]
+  discovery:
+    type: foxtrot_simple
+    disableMulticast: true
+    members: ["localhost:5701"]
 
 logging:
   level: INFO

--- a/foxtrot-core/pom.xml
+++ b/foxtrot-core/pom.xml
@@ -114,13 +114,13 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.6</version>
+            <version>3.6.2</version>
         </dependency>
 
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.6</version>
+            <version>3.6.2</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/foxtrot-core/pom.xml
+++ b/foxtrot-core/pom.xml
@@ -114,13 +114,13 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.5.3</version>
+            <version>3.6</version>
         </dependency>
 
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.5.3</version>
+            <version>3.6</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -151,6 +151,8 @@
             <artifactId>aspectjrt</artifactId>
             <version>1.8.7</version>
         </dependency>
+
+
     </dependencies>
     <build>
         <plugins>

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/AwsClusterDiscoveryConfig.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/AwsClusterDiscoveryConfig.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2016 Flipkart Internet Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.flipkart.foxtrot.core.querystore.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author phaneesh
+ */
+public class AwsClusterDiscoveryConfig extends ClusterDiscoveryConfig {
+
+    @JsonProperty
+    private String accessKey;
+    @JsonProperty
+    private String secretKey;
+    @JsonProperty
+    private String region = "us-east-1";
+    @JsonProperty
+    private String securityGroupName;
+    @JsonProperty
+    private String tagKey;
+    @JsonProperty
+    private String tagValue;
+    @JsonProperty
+    private String hostHeader = "ec2.amazonaws.com";
+    @JsonProperty
+    private String iamRole;
+    @JsonProperty
+    private int connectionTimeoutSeconds = 5;
+
+    public AwsClusterDiscoveryConfig() {
+        super(ClusterDiscoveryType.foxtrot_aws);
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getSecurityGroupName() {
+        return securityGroupName;
+    }
+
+    public void setSecurityGroupName(String securityGroupName) {
+        this.securityGroupName = securityGroupName;
+    }
+
+    public String getTagKey() {
+        return tagKey;
+    }
+
+    public void setTagKey(String tagKey) {
+        this.tagKey = tagKey;
+    }
+
+    public String getTagValue() {
+        return tagValue;
+    }
+
+    public void setTagValue(String tagValue) {
+        this.tagValue = tagValue;
+    }
+
+    public String getHostHeader() {
+        return hostHeader;
+    }
+
+    public void setHostHeader(String hostHeader) {
+        this.hostHeader = hostHeader;
+    }
+
+    public String getIamRole() {
+        return iamRole;
+    }
+
+    public void setIamRole(String iamRole) {
+        this.iamRole = iamRole;
+    }
+
+    public int getConnectionTimeoutSeconds() {
+        return connectionTimeoutSeconds;
+    }
+
+    public void setConnectionTimeoutSeconds(int connectionTimeoutSeconds) {
+        this.connectionTimeoutSeconds = connectionTimeoutSeconds;
+    }
+}

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ClusterConfig.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ClusterConfig.java
@@ -28,24 +28,18 @@ import java.util.List;
  * Time: 2:12 PM
  */
 public class ClusterConfig {
+
     @JsonProperty("name")
     @Valid
     @NotNull
     @NotEmpty
     private String name = null;
 
-//    @JsonProperty("server-url")
-//    @NotNull
-//    @NotEmpty
-//    private String webServerUrl = null;
-
-    @JsonProperty
-    private boolean disableMulticast = false;
-
-    @JsonProperty
-    private List<String> members = null;
+    @JsonProperty("discovery")
+    private ClusterDiscoveryConfig discovery;
 
     public ClusterConfig() {
+
     }
 
     public String getName() {
@@ -56,27 +50,11 @@ public class ClusterConfig {
         this.name = name;
     }
 
-//    public String getWebServerUrl() {
-//        return webServerUrl;
-//    }
-//
-//    public void setWebServerUrl(String webServerUrl) {
-//        this.webServerUrl = webServerUrl;
-//    }
-
-    public boolean isDisableMulticast() {
-        return disableMulticast;
+    public ClusterDiscoveryConfig getDiscovery() {
+        return discovery;
     }
 
-    public void setDisableMulticast(boolean disableMulticast) {
-        this.disableMulticast = disableMulticast;
-    }
-
-    public List<String> getMembers() {
-        return members;
-    }
-
-    public void setMembers(List<String> members) {
-        this.members = members;
+    public void setDiscovery(ClusterDiscoveryConfig discovery) {
+        this.discovery = discovery;
     }
 }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ClusterDiscoveryConfig.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ClusterDiscoveryConfig.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2014 Flipkart Internet Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.flipkart.foxtrot.core.querystore.impl;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import javax.validation.constraints.NotNull;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", visible = true)
+public abstract class ClusterDiscoveryConfig {
+
+    @NotNull
+    private final ClusterDiscoveryType type;
+
+    protected ClusterDiscoveryConfig(final ClusterDiscoveryType type) {
+        this.type = type;
+    }
+
+
+    public ClusterDiscoveryType getType() {
+        return this.type;
+    }
+}

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ClusterDiscoveryType.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ClusterDiscoveryType.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2014 Flipkart Internet Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.flipkart.foxtrot.core.querystore.impl;
+
+public enum ClusterDiscoveryType {
+   foxtrot_simple,
+   foxtrot_marathon,
+   foxtrot_aws
+}

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/MarathonClusterDiscoveryConfig.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/MarathonClusterDiscoveryConfig.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2016 Flipkart Internet Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.flipkart.foxtrot.core.querystore.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MarathonClusterDiscoveryConfig extends ClusterDiscoveryConfig {
+
+    @JsonProperty
+    private String endpoint;
+
+    @JsonProperty
+    private String app;
+
+    @JsonProperty
+    private String portIndex;
+
+    public MarathonClusterDiscoveryConfig() {
+        super(ClusterDiscoveryType.foxtrot_marathon);
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getApp() {
+        return app;
+    }
+
+    public void setApp(String app) {
+        this.app = app;
+    }
+
+    public String getPortIndex() {
+        return portIndex;
+    }
+
+    public void setPortIndex(String portIndex) {
+        this.portIndex = portIndex;
+    }
+}

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/SimpleClusterDiscoveryConfig.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/SimpleClusterDiscoveryConfig.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Flipkart Internet Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.flipkart.foxtrot.core.querystore.impl;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class SimpleClusterDiscoveryConfig extends ClusterDiscoveryConfig {
+
+    @JsonProperty
+    private List<String> members = null;
+
+    @JsonProperty
+    private boolean disableMulticast = false;
+
+    public SimpleClusterDiscoveryConfig() {
+        super(ClusterDiscoveryType.foxtrot_simple);
+    }
+
+    public List<String> getMembers() {
+        return members;
+    }
+
+    public void setMembers(List<String> members) {
+        this.members = members;
+    }
+
+    public boolean isDisableMulticast() {
+        return disableMulticast;
+    }
+
+    public void setDisableMulticast(boolean disableMulticast) {
+        this.disableMulticast = disableMulticast;
+    }
+}

--- a/foxtrot-server/pom.xml
+++ b/foxtrot-server/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.5.3</version>
+            <version>3.6</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,14 @@
             <name>HDP Releases</name>
             <url>http://repo.hortonworks.com/content/repositories/releases/</url>
         </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-phaneesh-maven</id>
+            <name>bintray</name>
+            <url>http://dl.bintray.com/phaneesh/maven</url>
+        </repository>
     </repositories>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -98,16 +98,12 @@
             <artifactId>hbase-ds</artifactId>
             <version>0.0.2-SNAPSHOT</version>
         </dependency>
-        <!--<dependency>-->
-            <!--<groupId>xerces</groupId>-->
-            <!--<artifactId>xercesImpl</artifactId>-->
-            <!--<version>2.11.0</version>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>xalan</groupId>-->
-            <!--<artifactId>xalan</artifactId>-->
-            <!--<version>2.7.2</version>-->
-        <!--</dependency>-->
+        <!-- Hazelcast Marathon discovery SPI -->
+        <dependency>
+            <groupId>com.marathon.hazelcast.servicediscovery</groupId>
+            <artifactId>hazelcast-marathon-discovery</artifactId>
+            <version>0.0.2</version>
+        </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,9 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <id>bintray-phaneesh-maven</id>
+            <id>bintray</id>
             <name>bintray</name>
-            <url>http://dl.bintray.com/phaneesh/maven</url>
+            <url>http://jcenter.bintray.com</url>
         </repository>
     </repositories>
 
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>com.marathon.hazelcast.servicediscovery</groupId>
             <artifactId>hazelcast-marathon-discovery</artifactId>
-            <version>0.0.2</version>
+            <version>0.0.3</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
1) Support hazelcast cluster discovery on Marathon (With random port & host assignment)
2) Auto detect Marathon/container runtimes for registering cluster membership
3) Added bonus: AWS discovery support for hazelcast