### PR TITLE
Added support for older row keys

### DIFF
--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/DocumentMetadata.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/DocumentMetadata.java
@@ -1,5 +1,7 @@
 package com.flipkart.foxtrot.common;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 /**
  * Metadata for a document
  */
@@ -33,9 +35,9 @@ public class DocumentMetadata {
 
     @Override
     public String toString() {
-        return "DocumentMetadata{" +
-                "id='" + id + '\'' +
-                ", rawStorageId='" + rawStorageId + '\'' +
-                '}';
+        return new ToStringBuilder(this)
+                .append("id", id)
+                .append("rawStorageId", rawStorageId)
+                .toString();
     }
 }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/impl/hbase/HBaseDataStore.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/impl/hbase/HBaseDataStore.java
@@ -260,7 +260,7 @@ public class HBaseDataStore implements DataStore {
 
     @VisibleForTesting
     public Put getPutForDocument(Document document) throws JsonProcessingException {
-        return new Put(Bytes.toBytes(document.getId()))
+        return new Put(Bytes.toBytes(document.getMetadata().getRawStorageId()))
                 .add(COLUMN_FAMILY, DOCUMENT_META_FIELD_NAME, mapper.writeValueAsBytes(document.getMetadata()))
                 .add(COLUMN_FAMILY, DOCUMENT_FIELD_NAME, mapper.writeValueAsBytes(document.getData()))
                 .add(COLUMN_FAMILY, TIMESTAMP_FIELD_NAME, Bytes.toBytes(document.getTimestamp()));

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/impl/hbase/HBaseDataStore.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/impl/hbase/HBaseDataStore.java
@@ -21,13 +21,12 @@ import com.flipkart.foxtrot.common.Document;
 import com.flipkart.foxtrot.common.DocumentMetadata;
 import com.flipkart.foxtrot.common.Table;
 import com.flipkart.foxtrot.core.datastore.DataStore;
-import com.flipkart.foxtrot.core.exception.FoxtrotExceptions;
 import com.flipkart.foxtrot.core.exception.FoxtrotException;
+import com.flipkart.foxtrot.core.exception.FoxtrotExceptions;
 import com.flipkart.foxtrot.core.querystore.DocumentTranslator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import com.shash.hbase.ds.RowKeyDistributorByHashPrefix;
 import com.yammer.metrics.annotation.Timed;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTableInterface;
@@ -60,11 +59,10 @@ public class HBaseDataStore implements DataStore {
     private final ObjectMapper mapper;
     private final DocumentTranslator translator;
 
-    public HBaseDataStore(HbaseTableConnection tableWrapper, ObjectMapper mapper) {
+    public HBaseDataStore(HbaseTableConnection tableWrapper, ObjectMapper mapper, DocumentTranslator translator) {
         this.tableWrapper = tableWrapper;
         this.mapper = mapper;
-        this.translator = new DocumentTranslator(new RowKeyDistributorByHashPrefix(
-                new RowKeyDistributorByHashPrefix.OneByteSimpleHash(tableWrapper.getHbaseConfig().getNumBuckets())));
+        this.translator = translator;
     }
 
     @Override

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/impl/hbase/HbaseConfig.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/impl/hbase/HbaseConfig.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2014 Flipkart Internet Pvt. Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,6 +45,7 @@ public class HbaseConfig {
     @Max(Byte.MAX_VALUE)
     private short numBuckets = 32;
 
+    private String rawKeyVersion = "1.0";
 
     @NotNull
     @NotEmpty
@@ -155,6 +156,14 @@ public class HbaseConfig {
 
     public void setHbaseZookeeperQuorum(String hbaseZookeeperQuorum) {
         this.hbaseZookeeperQuorum = hbaseZookeeperQuorum;
+    }
+
+    public String getRawKeyVersion() {
+        return rawKeyVersion;
+    }
+
+    public void setRawKeyVersion(String rawKeyVersion) {
+        this.rawKeyVersion = rawKeyVersion;
     }
 
     public int getNumBuckets() {

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/impl/hbase/IdentityKeyDistributor.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/datastore/impl/hbase/IdentityKeyDistributor.java
@@ -1,0 +1,31 @@
+package com.flipkart.foxtrot.core.datastore.impl.hbase;
+
+import com.shash.hbase.ds.AbstractRowKeyDistributor;
+
+public class IdentityKeyDistributor extends AbstractRowKeyDistributor {
+
+    @Override
+    public byte[] getDistributedKey(byte[] bytes) {
+        return bytes;
+    }
+
+    @Override
+    public byte[] getOriginalKey(byte[] bytes) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[][] getAllDistributedKeys(byte[] bytes) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getParamsToStore() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void init(String s) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/DocumentTranslator.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/DocumentTranslator.java
@@ -3,9 +3,14 @@ package com.flipkart.foxtrot.core.querystore;
 import com.flipkart.foxtrot.common.Document;
 import com.flipkart.foxtrot.common.DocumentMetadata;
 import com.flipkart.foxtrot.common.Table;
+import com.flipkart.foxtrot.common.util.CollectionUtils;
+import com.flipkart.foxtrot.core.datastore.impl.hbase.HbaseConfig;
+import com.flipkart.foxtrot.core.datastore.impl.hbase.IdentityKeyDistributor;
+import com.flipkart.foxtrot.core.querystore.actions.Constants;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.shash.hbase.ds.AbstractRowKeyDistributor;
+import com.shash.hbase.ds.RowKeyDistributorByHashPrefix;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,19 +21,28 @@ import java.util.List;
  * Created by santanu.s on 24/11/15.
  */
 public class DocumentTranslator {
-    private static final String CURRENT_RAW_KEY_VERSION = "__RAW_KEY_VERSION_2__";
 
     private static final Logger logger = LoggerFactory.getLogger(DocumentTranslator.class);
 
+    private String rawKeyVersion;
     private final AbstractRowKeyDistributor keyDistributor;
 
-    public DocumentTranslator(AbstractRowKeyDistributor keyDistributor) {
-        this.keyDistributor = keyDistributor;
+    public DocumentTranslator(HbaseConfig hbaseConfig) {
+        if (CollectionUtils.isNullOrEmpty(hbaseConfig.getRawKeyVersion())
+                || hbaseConfig.getRawKeyVersion().equalsIgnoreCase("1.0")) {
+            this.keyDistributor = new IdentityKeyDistributor();
+            this.rawKeyVersion = "1.0";
+        } else if (hbaseConfig.getRawKeyVersion().equalsIgnoreCase("2.0")) {
+            this.keyDistributor = new RowKeyDistributorByHashPrefix(new RowKeyDistributorByHashPrefix.OneByteSimpleHash(32));
+            this.rawKeyVersion = "2.0";
+        } else {
+            throw new IllegalArgumentException(String.format("rawKeyVersion not supported version=[%s]", hbaseConfig.getRawKeyVersion()));
+        }
     }
 
     public List<Document> translate(final Table table, final List<Document> inDocuments) {
         ImmutableList.Builder<Document> docListBuilder = ImmutableList.builder();
-        for(Document document : inDocuments) {
+        for (Document document : inDocuments) {
             docListBuilder.add(translate(table, document));
         }
         return docListBuilder.build();
@@ -38,22 +52,21 @@ public class DocumentTranslator {
         Document document = new Document();
         DocumentMetadata metadata = metadata(table, inDocument);
 
-        document.setId(metadata.getRawStorageId());
+        switch (rawKeyVersion) {
+            case "1.0":
+                document.setId(inDocument.getId());
+                break;
+            case "2.0":
+                document.setId(metadata.getRawStorageId());
+                break;
+            default:
+                throw new IllegalArgumentException(String.format("rawKeyVersion not supported version=[%s]", rawKeyVersion));
+        }
         document.setTimestamp(inDocument.getTimestamp());
         document.setMetadata(metadata);
         document.setData(inDocument.getData());
 
         return document;
-    }
-
-    public List<Document> translateBack(final List<Document> inDocuments) {
-        ImmutableList.Builder<Document> listBuilder = ImmutableList.builder();
-        if(null != inDocuments) {
-            for (Document document : inDocuments) {
-                listBuilder.add(translateBack(document));
-            }
-        }
-        return listBuilder.build();
     }
 
     public Document translateBack(final Document inDocument) {
@@ -71,13 +84,20 @@ public class DocumentTranslator {
         metadata.setRawStorageId(rowKey);
         metadata.setId(inDocument.getId());
 
-        logger.debug("Doc row key: {}, {}", rowKey, inDocument);
+        logger.debug("Doc row key: {}, {}, {}", rowKey, inDocument, metadata);
         return metadata;
     }
 
     public String rawStorageIdFromDocument(final Table table, final Document document) {
-        return String.format("%s:%020d:%s:%s",
-                table.getName(), document.getTimestamp(), document.getId(), CURRENT_RAW_KEY_VERSION);
+        switch (rawKeyVersion) {
+            case "1.0":
+                return document.getId() + ":" + table.getName();
+            case "2.0":
+                return String.format("%s:%020d:%s:%s",
+                        table.getName(), document.getTimestamp(), document.getId(), Constants.rawKeyVersionToSuffixMap.get(rawKeyVersion));
+            default:
+                throw new IllegalArgumentException(String.format("rawKeyVersion not supported version=[%s]", rawKeyVersion));
+        }
     }
 
     @VisibleForTesting
@@ -86,10 +106,11 @@ public class DocumentTranslator {
     }
 
     public String rawStorageIdFromDocumentId(Table table, String id) {
-        if(!id.endsWith(CURRENT_RAW_KEY_VERSION)) {
-            return String.format("%s:%s", id, table.getName());
+        if (id.endsWith(Constants.rawKeyVersionToSuffixMap.get("2.0"))) {
+            return id;
         }
+
+        return String.format("%s:%s", id, table.getName());
         //IMPLEMENTOR NOTE:: Handle older versions here
-        return id;
     }
 }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/Constants.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/Constants.java
@@ -15,7 +15,8 @@
  */
 package com.flipkart.foxtrot.core.querystore.actions;
 
-import java.util.HashMap;
+import com.google.common.collect.ImmutableMap;
+
 import java.util.Map;
 
 /**
@@ -23,11 +24,8 @@ import java.util.Map;
  */
 public class Constants {
 
-    public static Map<String, String> rawKeyVersionToSuffixMap = new HashMap<String, String>() {{
-        put("1.0", null);
-        put("2.0", "__RAW_KEY_VERSION_2__");
-    }};
-
+    public static final Map<String, String> rawKeyVersionToSuffixMap = ImmutableMap.<String, String>builder()
+            .put("2.0", "__RAW_KEY_VERSION_2__").build();
 
     public static final String FIELD_REPLACEMENT_REGEX = "[^a-zA-Z0-9\\-_]";
     public static final String FIELD_REPLACEMENT_VALUE = "_";

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/Constants.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/Constants.java
@@ -15,10 +15,20 @@
  */
 package com.flipkart.foxtrot.core.querystore.actions;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Created by rishabh.goyal on 14/05/14.
  */
 public class Constants {
+
+    public static Map<String, String> rawKeyVersionToSuffixMap = new HashMap<String, String>() {{
+        put("1.0", null);
+        put("2.0", "__RAW_KEY_VERSION_2__");
+    }};
+
+
     public static final String FIELD_REPLACEMENT_REGEX = "[^a-zA-Z0-9\\-_]";
     public static final String FIELD_REPLACEMENT_VALUE = "_";
     public static final String SEPARATOR = "_--&--_";

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/TestUtils.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/TestUtils.java
@@ -25,6 +25,7 @@ import com.flipkart.foxtrot.core.datastore.impl.hbase.HBaseDataStore;
 import com.flipkart.foxtrot.core.datastore.impl.hbase.HbaseConfig;
 import com.flipkart.foxtrot.core.datastore.impl.hbase.HbaseTableConnection;
 import com.flipkart.foxtrot.core.exception.FoxtrotException;
+import com.flipkart.foxtrot.core.querystore.DocumentTranslator;
 import com.flipkart.foxtrot.core.querystore.actions.spi.ActionMetadata;
 import com.flipkart.foxtrot.core.querystore.actions.spi.AnalyticsLoader;
 import com.flipkart.foxtrot.core.querystore.actions.spi.AnalyticsProvider;
@@ -56,7 +57,8 @@ public class TestUtils {
         HbaseTableConnection tableConnection = Mockito.mock(HbaseTableConnection.class);
         doReturn(tableInterface).when(tableConnection).getTable(Matchers.<Table>any());
         doReturn(new HbaseConfig()).when(tableConnection).getHbaseConfig();
-        HBaseDataStore hBaseDataStore = new HBaseDataStore(tableConnection, new ObjectMapper());
+        HBaseDataStore hBaseDataStore = new HBaseDataStore(tableConnection, new ObjectMapper(),
+                new DocumentTranslator(TestUtils.createHBaseConfigWithRawKeyV2()));
         hBaseDataStore = spy(hBaseDataStore);
         return hBaseDataStore;
     }
@@ -96,6 +98,27 @@ public class TestUtils {
             logger.info("Registered action: " + action.getCanonicalName());
         }
         mapper.getSubtypeResolver().registerSubtypes(types.toArray(new NamedType[types.size()]));
+    }
+
+
+    public static HbaseConfig createHBaseConfigWithRawKeyV1() {
+        HbaseConfig hbaseConfig = new HbaseConfig();
+        hbaseConfig.setRawKeyVersion("1.0");
+        return hbaseConfig;
+    }
+
+    public static HbaseConfig createHBaseConfigWithRawKeyV2() {
+        HbaseConfig hbaseConfig = new HbaseConfig();
+        hbaseConfig.setRawKeyVersion("2.0");
+        return hbaseConfig;
+    }
+
+    public static Document translatedDocumentWithRowKeyVersion1(Table table, Document document) {
+        return new DocumentTranslator(createHBaseConfigWithRawKeyV1()).translate(table, document);
+    }
+
+    public static Document translatedDocumentWithRowKeyVersion2(Table table, Document document) {
+        return new DocumentTranslator(createHBaseConfigWithRawKeyV2()).translate(table, document);
     }
 
     public static List<Document> getQueryDocuments(ObjectMapper mapper) {

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/datastore/impl/hbase/HBaseDataStoreTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/datastore/impl/hbase/HBaseDataStoreTest.java
@@ -21,12 +21,12 @@ import com.flipkart.foxtrot.common.Document;
 import com.flipkart.foxtrot.common.DocumentMetadata;
 import com.flipkart.foxtrot.common.Table;
 import com.flipkart.foxtrot.core.MockHTable;
+import com.flipkart.foxtrot.core.TestUtils;
 import com.flipkart.foxtrot.core.exception.ErrorCode;
 import com.flipkart.foxtrot.core.exception.FoxtrotException;
 import com.flipkart.foxtrot.core.querystore.DocumentTranslator;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.shash.hbase.ds.RowKeyDistributorByHashPrefix;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Put;
@@ -49,45 +49,59 @@ import static org.mockito.Mockito.*;
  */
 
 public class HBaseDataStoreTest {
-    private HBaseDataStore HBaseDataStore;
+    private HBaseDataStore hbaseDataStore;
     private HTableInterface tableInterface;
-    private HbaseTableConnection hBaseTableConnection;
+    private HbaseTableConnection hbaseTableConnection;
     private ObjectMapper mapper = new ObjectMapper();
 
     private static final byte[] COLUMN_FAMILY = Bytes.toBytes("d");
     private static final byte[] DATA_FIELD_NAME = Bytes.toBytes("data");
     private static final String TEST_APP_NAME = "test-app";
     private static final Table TEST_APP = new Table(TEST_APP_NAME, 7);
-    private final DocumentTranslator translator = new DocumentTranslator(new RowKeyDistributorByHashPrefix(
-            new RowKeyDistributorByHashPrefix.OneByteSimpleHash(32)));
-
 
     @Before
     public void setUp() throws Exception {
         tableInterface = MockHTable.create();
         tableInterface = spy(tableInterface);
-        hBaseTableConnection = Mockito.mock(HbaseTableConnection.class);
-        when(hBaseTableConnection.getTable(Matchers.<Table>any())).thenReturn(tableInterface);
-        when(hBaseTableConnection.getHbaseConfig()).thenReturn(new HbaseConfig());
-        HBaseDataStore = new HBaseDataStore(hBaseTableConnection, mapper);
+        this.hbaseTableConnection = Mockito.mock(HbaseTableConnection.class);
+        when(hbaseTableConnection.getTable(Matchers.<Table>any())).thenReturn(tableInterface);
+        when(hbaseTableConnection.getHbaseConfig()).thenReturn(new HbaseConfig());
+        hbaseDataStore = new HBaseDataStore(hbaseTableConnection, mapper,
+                new DocumentTranslator(TestUtils.createHBaseConfigWithRawKeyV1()));
     }
 
     @Test
     public void testSaveSingle() throws Exception {
+        // rawKeyVersion 1.0
+        hbaseDataStore = new HBaseDataStore(hbaseTableConnection,
+                mapper,
+                new DocumentTranslator(TestUtils.createHBaseConfigWithRawKeyV1()));
         Document expectedDocument = new Document();
         expectedDocument.setId(UUID.randomUUID().toString());
         expectedDocument.setTimestamp(System.currentTimeMillis());
         JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
         expectedDocument.setData(data);
-        HBaseDataStore.save(TEST_APP, expectedDocument);
-        validateSave(expectedDocument);
+        hbaseDataStore.save(TEST_APP, expectedDocument);
+        validateSave(expectedDocument.getId(), expectedDocument);
+
+        // rawKeyVersion 2.0
+        hbaseDataStore = new HBaseDataStore(hbaseTableConnection,
+                mapper,
+                new DocumentTranslator(TestUtils.createHBaseConfigWithRawKeyV2()));
+        expectedDocument = new Document();
+        expectedDocument.setId(UUID.randomUUID().toString());
+        expectedDocument.setTimestamp(System.currentTimeMillis());
+        data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
+        expectedDocument.setData(data);
+        Document savedDocument = hbaseDataStore.save(TEST_APP, expectedDocument);
+        validateSave(savedDocument.getId(), expectedDocument);
     }
 
     @Test
     public void testSaveSingleNullDocument() throws Exception {
         Document document = null;
         try {
-            HBaseDataStore.save(TEST_APP, document);
+            hbaseDataStore.save(TEST_APP, document);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.INVALID_REQUEST, ex.getCode());
@@ -96,9 +110,10 @@ public class HBaseDataStoreTest {
 
     @Test
     public void testSaveSingleNullId() throws Exception {
-        Document document = new Document(null, System.currentTimeMillis(), mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST")));
+        Document document = createDummyDocument();
+        document.setId(null);
         try {
-            HBaseDataStore.save(TEST_APP, document);
+            hbaseDataStore.save(TEST_APP, document);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.INVALID_REQUEST, ex.getCode());
@@ -109,7 +124,7 @@ public class HBaseDataStoreTest {
     public void testSaveSingleNullData() throws Exception {
         Document document = new Document(UUID.randomUUID().toString(), System.currentTimeMillis(), null);
         try {
-            HBaseDataStore.save(TEST_APP, document);
+            hbaseDataStore.save(TEST_APP, document);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.INVALID_REQUEST, ex.getCode());
@@ -125,7 +140,7 @@ public class HBaseDataStoreTest {
                 .when(tableInterface)
                 .put(Matchers.<Put>any());
         try {
-            HBaseDataStore.save(TEST_APP, document);
+            hbaseDataStore.save(TEST_APP, document);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.STORE_CONNECTION_ERROR, ex.getCode());
@@ -140,7 +155,7 @@ public class HBaseDataStoreTest {
         doThrow(new IOException())
                 .when(tableInterface)
                 .close();
-        HBaseDataStore.save(TEST_APP, document);
+        hbaseDataStore.save(TEST_APP, document);
         verify(tableInterface, times(1)).close();
     }
 
@@ -154,9 +169,9 @@ public class HBaseDataStoreTest {
                     System.currentTimeMillis(),
                     mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"))));
         }
-        HBaseDataStore.saveAll(TEST_APP, documents);
+        hbaseDataStore.saveAll(TEST_APP, documents);
         for (Document document : documents) {
-            validateSave(document);
+            validateSave(document.getId(), document);
         }
     }
 
@@ -167,7 +182,7 @@ public class HBaseDataStoreTest {
             documents.add(null);
         }
         try {
-            HBaseDataStore.saveAll(TEST_APP, documents);
+            hbaseDataStore.saveAll(TEST_APP, documents);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.INVALID_REQUEST, ex.getCode());
@@ -178,7 +193,7 @@ public class HBaseDataStoreTest {
     public void testSaveBulkNullIdList() throws Exception {
         List<Document> documents = null;
         try {
-            HBaseDataStore.saveAll(TEST_APP, documents);
+            hbaseDataStore.saveAll(TEST_APP, documents);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.INVALID_REQUEST, ex.getCode());
@@ -192,7 +207,7 @@ public class HBaseDataStoreTest {
             documents.add(new Document(null, System.currentTimeMillis(), mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"))));
         }
         try {
-            HBaseDataStore.saveAll(TEST_APP, documents);
+            hbaseDataStore.saveAll(TEST_APP, documents);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.INVALID_REQUEST, ex.getCode());
@@ -206,7 +221,7 @@ public class HBaseDataStoreTest {
             documents.add(new Document(UUID.randomUUID().toString(), System.currentTimeMillis(), null));
         }
         try {
-            HBaseDataStore.saveAll(TEST_APP, documents);
+            hbaseDataStore.saveAll(TEST_APP, documents);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.INVALID_REQUEST, ex.getCode());
@@ -223,7 +238,7 @@ public class HBaseDataStoreTest {
                 .when(tableInterface)
                 .put(Matchers.anyListOf(Put.class));
         try {
-            HBaseDataStore.saveAll(TEST_APP, documents);
+            hbaseDataStore.saveAll(TEST_APP, documents);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.STORE_CONNECTION_ERROR, ex.getCode());
@@ -239,19 +254,18 @@ public class HBaseDataStoreTest {
         doThrow(new IOException())
                 .when(tableInterface)
                 .close();
-        HBaseDataStore.saveAll(TEST_APP, documents);
+        hbaseDataStore.saveAll(TEST_APP, documents);
         verify(tableInterface, times(1)).close();
     }
 
-    public void validateSave(Document savedDocument) throws Exception {
-        String rowkey = translator.rawStorageIdFromDocument(TEST_APP, savedDocument);
-        Get get = new Get(Bytes.toBytes(translator.generateScalableKey(translator.rawStorageIdFromDocumentId(TEST_APP, rowkey))));
+    public void validateSave(String id, Document expectedDocument) throws Exception {
+        Get get = new Get(Bytes.toBytes(id));
         Result result = tableInterface.get(get);
         assertNotNull("Get for Id should not be null", result);
-        Document actualDocument = new Document(savedDocument.getId(),
-                savedDocument.getTimestamp(),
+        Document actualDocument = new Document(expectedDocument.getId(),
+                expectedDocument.getTimestamp(),
                 mapper.readTree(result.getValue(COLUMN_FAMILY, DATA_FIELD_NAME)));
-        compare(savedDocument, actualDocument);
+        compare(expectedDocument, actualDocument);
     }
 
     private String v1FormatKey(String id) {
@@ -259,33 +273,41 @@ public class HBaseDataStoreTest {
     }
 
     @Test
-    public void testGetSingleV1Format() throws Exception {
-        String id = UUID.randomUUID().toString();
-        JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
-        final String newId = v1FormatKey(id);
-        Document expectedDocument = new Document(newId, System.currentTimeMillis(),
-                new DocumentMetadata(newId, "row.1"), data);
-        tableInterface.put(HBaseDataStore.getPutForDocument(expectedDocument));
-        Document actualDocument = HBaseDataStore.get(TEST_APP, id);
-        compare(expectedDocument, actualDocument);
-    }
+    public void testGetSingle() throws Exception {
+        // rawKeyVersion 1.0
+        hbaseDataStore = new HBaseDataStore(hbaseTableConnection,
+                mapper,
+                new DocumentTranslator(TestUtils.createHBaseConfigWithRawKeyV1()));
 
-    @Test
-    public void testGetSingleV2Format() throws Exception {
         String id = UUID.randomUUID().toString();
-        long timestamp = System.currentTimeMillis();
         JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
-        Document originalDocument = new Document(id, timestamp, data);
-        final String newId = translator.generateScalableKey(translator.rawStorageIdFromDocument(TEST_APP, originalDocument));
-        tableInterface.put(HBaseDataStore.getPutForDocument(translator.translate(TEST_APP, originalDocument)));
-        Document actualDocument = HBaseDataStore.get(TEST_APP, newId);
-        compare(originalDocument, actualDocument);
+        String newId = v1FormatKey(id);
+        Document expectedDocument = new Document(newId, System.currentTimeMillis(), new DocumentMetadata(newId, "row.1"), data);
+        tableInterface.put(hbaseDataStore.getPutForDocument(expectedDocument));
+        Document actualDocument = hbaseDataStore.get(TEST_APP, id);
+
+        compare(expectedDocument, actualDocument);
+
+
+        // rawKeyVersion 2.0
+        DocumentTranslator documentTranslator = new DocumentTranslator(TestUtils.createHBaseConfigWithRawKeyV2());
+        hbaseDataStore = new HBaseDataStore(hbaseTableConnection, mapper, documentTranslator);
+
+        id = UUID.randomUUID().toString();
+        data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
+        Document originalDocument = new Document(id, System.currentTimeMillis(), data);
+        newId = documentTranslator.translate(TEST_APP, originalDocument).getId();
+        expectedDocument = new Document(newId, originalDocument.getTimestamp(), new DocumentMetadata(newId, "row.1"), data);
+        tableInterface.put(hbaseDataStore.getPutForDocument(expectedDocument));
+        actualDocument = hbaseDataStore.get(TEST_APP, newId);
+        compare(expectedDocument, actualDocument);
+
     }
 
     @Test
     public void testGetSingleMissingDocument() {
         try {
-            HBaseDataStore.get(TEST_APP, UUID.randomUUID().toString());
+            hbaseDataStore.get(TEST_APP, UUID.randomUUID().toString());
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.DOCUMENT_NOT_FOUND, ex.getCode());
@@ -298,12 +320,12 @@ public class HBaseDataStoreTest {
         JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
 
         Document expectedDocument = new Document(id, System.currentTimeMillis(), data);
-        tableInterface.put(HBaseDataStore.getPutForDocument(expectedDocument));
+        tableInterface.put(hbaseDataStore.getPutForDocument(expectedDocument));
         doThrow(new IOException())
                 .when(tableInterface)
                 .get(Matchers.<Get>any());
         try {
-            HBaseDataStore.get(TEST_APP, id);
+            hbaseDataStore.get(TEST_APP, id);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.STORE_CONNECTION_ERROR, ex.getCode());
@@ -312,24 +334,24 @@ public class HBaseDataStoreTest {
 
     @Test
     public void testGetSingleHBaseCloseException() throws Exception {
-        String id = UUID.randomUUID().toString();
-        JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
+        Document originalDocument = createDummyDocument();
+        Document expectedDocument = new Document(v1FormatKey(originalDocument.getId()),
+                originalDocument.getTimestamp(),
+                originalDocument.getData());
 
-        Document expectedDocument = new Document(id, System.currentTimeMillis(), data);
-        Document translated = translator.translate(TEST_APP, expectedDocument);
-        tableInterface.put(HBaseDataStore.getPutForDocument(translated));
+        tableInterface.put(hbaseDataStore.getPutForDocument(expectedDocument));
         doThrow(new IOException())
                 .when(tableInterface)
                 .close();
-        HBaseDataStore.get(TEST_APP, translated.getId());
+        hbaseDataStore.get(TEST_APP, originalDocument.getId());
         verify(tableInterface, times(1)).close();
     }
 
     @Test
     public void testV1GetBulk() throws Exception {
         Map<String, Document> idValues = Maps.newHashMap();
-        List<String> ids = new Vector<String>();
-        List<Put> putList = new Vector<Put>();
+        List<String> ids = new Vector<>();
+        List<Put> putList = new Vector<>();
         HashMap<String, Document> actualIdValues = Maps.newHashMap();
         for (int i = 0; i < 10; i++) {
             String id = UUID.randomUUID().toString();
@@ -339,11 +361,11 @@ public class HBaseDataStoreTest {
             ids.add(id);
             Document document = new Document(rawId, timestamp,
                     new DocumentMetadata(id, rawId), data);
-            putList.add(HBaseDataStore.getPutForDocument(document));
+            putList.add(hbaseDataStore.getPutForDocument(document));
             idValues.put(id, new Document(id, timestamp, data));
         }
         tableInterface.put(putList);
-        List<Document> actualDocuments = HBaseDataStore.getAll(TEST_APP, ids);
+        List<Document> actualDocuments = hbaseDataStore.getAll(TEST_APP, ids);
         for (Document doc : actualDocuments) {
             actualIdValues.put(doc.getId(), doc);
         }
@@ -356,24 +378,26 @@ public class HBaseDataStoreTest {
 
     @Test
     public void testV2GetBulk() throws Exception {
+        DocumentTranslator translator = new DocumentTranslator(TestUtils.createHBaseConfigWithRawKeyV2());
+
         Map<String, Document> idValues = Maps.newHashMap();
-        List<String> ids = new Vector<String>();
-        List<String> rawIds = new Vector<String>();
-        List<Put> putList = new Vector<Put>();
+        List<String> ids = Lists.newArrayList();
+        List<String> rawIds = Lists.newArrayList();
+        List<Put> putList = Lists.newArrayList();
+
         HashMap<String, Document> actualIdValues = Maps.newHashMap();
         for (int i = 0; i < 10; i++) {
-            String id = UUID.randomUUID().toString();
-            long timestamp = System.currentTimeMillis();
-            JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "BULK_GET_TEST"));
-            ids.add(id);
-            Document document = new Document(id, timestamp, data);
+            Document document = createDummyDocument();
+            ids.add(document.getId());
+            idValues.put(document.getId(), document);
+
             Document translated = translator.translate(TEST_APP, document);
-            putList.add(HBaseDataStore.getPutForDocument(translated));
-            idValues.put(id, new Document(id, timestamp, data));
+            putList.add(hbaseDataStore.getPutForDocument(translated));
+
             rawIds.add(translated.getId());
         }
         tableInterface.put(putList);
-        List<Document> actualDocuments = HBaseDataStore.getAll(TEST_APP, rawIds);
+        List<Document> actualDocuments = hbaseDataStore.getAll(TEST_APP, rawIds);
         for (Document doc : actualDocuments) {
             actualIdValues.put(doc.getId(), doc);
         }
@@ -387,7 +411,7 @@ public class HBaseDataStoreTest {
     @Test
     public void testGetBulkNullIdList() throws Exception {
         try {
-            HBaseDataStore.getAll(TEST_APP, null);
+            hbaseDataStore.getAll(TEST_APP, null);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.INVALID_REQUEST, ex.getCode());
@@ -401,7 +425,7 @@ public class HBaseDataStoreTest {
             ids.add(UUID.randomUUID().toString());
         }
         try {
-            HBaseDataStore.getAll(TEST_APP, ids);
+            hbaseDataStore.getAll(TEST_APP, ids);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.DOCUMENT_NOT_FOUND, ex.getCode());
@@ -417,14 +441,14 @@ public class HBaseDataStoreTest {
             Document document = new Document(id, System.currentTimeMillis(),
                     new DocumentMetadata(id, String.format("row:%d", i)),
                     mapper.valueToTree(Collections.singletonMap("TEST_NAME", "BULK_GET_TEST")));
-            putList.add(HBaseDataStore.getPutForDocument(document));
+            putList.add(hbaseDataStore.getPutForDocument(document));
         }
         tableInterface.put(putList);
         doThrow(new IOException())
                 .when(tableInterface)
                 .get(Matchers.anyListOf(Get.class));
         try {
-            HBaseDataStore.getAll(TEST_APP, ids);
+            hbaseDataStore.getAll(TEST_APP, ids);
             fail();
         } catch (FoxtrotException ex) {
             assertEquals(ErrorCode.STORE_CONNECTION_ERROR, ex.getCode());
@@ -433,61 +457,21 @@ public class HBaseDataStoreTest {
 
     @Test
     public void testGetBulkHBaseCloseException() throws Exception {
-        List<String> ids = new Vector<String>();
-        List<Put> putList = new Vector<Put>();
+        List<String> ids = new Vector<>();
+        List<Put> putList = new Vector<>();
         for (int i = 0; i < 10; i++) {
             String id = UUID.randomUUID().toString();
             Document document = new Document(id, System.currentTimeMillis(),
                     new DocumentMetadata(id, String.format("row:%d", i)),
                     mapper.valueToTree(Collections.singletonMap("TEST_NAME", "BULK_GET_TEST")));
-            putList.add(HBaseDataStore.getPutForDocument(document));
+            putList.add(hbaseDataStore.getPutForDocument(document));
         }
         tableInterface.put(putList);
         doThrow(new IOException())
                 .when(tableInterface)
                 .close();
-        HBaseDataStore.getAll(TEST_APP, ids);
+        hbaseDataStore.getAll(TEST_APP, ids);
         verify(tableInterface, times(1)).close();
-    }
-
-    @Test
-    public void testBasicSetGet() throws Exception {
-        String id = UUID.randomUUID().toString();
-        long timestamp = System.currentTimeMillis();
-        JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
-        Document originalDocument = new Document(id, timestamp, data);
-        final String newId = translator.generateScalableKey(translator.rawStorageIdFromDocument(TEST_APP, originalDocument));
-        HBaseDataStore.save(TEST_APP, originalDocument);
-        Document actualDocument = HBaseDataStore.get(TEST_APP, newId);
-        compare(originalDocument, actualDocument);
-    }
-
-    @Test
-    public void testBasicBulkGetSet() throws Exception {
-        Map<String, Document> idValues = Maps.newHashMap();
-        List<String> ids = new Vector<String>();
-        HashMap<String, Document> actualIdValues = Maps.newHashMap();
-        List<Document> documents = Lists.newArrayList();
-        for (int i = 0; i < 10; i++) {
-            String id = UUID.randomUUID().toString();
-            long timestamp = System.currentTimeMillis();
-            JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "BULK_GET_TEST"));
-            ids.add(id);
-            Document document = new Document(id, timestamp, data);
-            idValues.put(id, document);
-            documents.add(document);
-        }
-        List<Document> translatedDocs = HBaseDataStore.saveAll(TEST_APP, documents);
-        List<String> rawIds = translatedDocs.stream().map(Document::getId).collect(Collectors.toCollection(ArrayList::new));
-        List<Document> actualDocuments = HBaseDataStore.getAll(TEST_APP, rawIds);
-        for (Document doc : actualDocuments) {
-            actualIdValues.put(doc.getId(), doc);
-        }
-        assertNotNull("List of returned Documents should not be null", actualDocuments);
-        for (String id : ids) {
-            assertTrue("Requested Id should be present in response", actualIdValues.containsKey(id));
-            compare(idValues.get(id), actualIdValues.get(id));
-        }
     }
 
     public void compare(Document expected, Document actual) throws Exception {
@@ -500,5 +484,14 @@ public class HBaseDataStoreTest {
         String expectedData = mapper.writeValueAsString(expected.getData());
         String actualData = mapper.writeValueAsString(actual.getData());
         assertEquals("Actual data should match expected data", expectedData, actualData);
+    }
+
+    private Document createDummyDocument() {
+        Document document = new Document();
+        document.setId(UUID.randomUUID().toString());
+        document.setTimestamp(System.currentTimeMillis());
+        JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
+        document.setData(data);
+        return document;
     }
 }

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/DocumentTranslatorTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/DocumentTranslatorTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 
 import java.util.UUID;
 
+import static org.junit.Assert.*;
+
 public class DocumentTranslatorTest {
 
     private static final ObjectMapper mapper = new ObjectMapper();
@@ -36,10 +38,10 @@ public class DocumentTranslatorTest {
 
         Document translatedDocument = translator.translate(table, document);
 
-        assert (translatedDocument.getId().equals(document.getId()));
-        assert (translatedDocument.getMetadata() != null);
-        assert (translatedDocument.getMetadata().getId().equals(document.getId()));
-        assert (translatedDocument.getMetadata().getRawStorageId().equals(document.getId() + ":" + table.getName()));
+        assertEquals(translatedDocument.getId(), document.getId());
+        assertNotNull(translatedDocument.getMetadata());
+        assertEquals(translatedDocument.getMetadata().getId(), document.getId());
+        assertEquals(translatedDocument.getMetadata().getRawStorageId(), document.getId() + ":" + table.getName());
     }
 
     @Test
@@ -55,10 +57,10 @@ public class DocumentTranslatorTest {
 
         Document translatedDocument = translator.translate(table, document);
 
-        assert (translatedDocument.getId().equals(document.getId()));
-        assert (translatedDocument.getMetadata() != null);
-        assert (translatedDocument.getMetadata().getId().equals(document.getId()));
-        assert (translatedDocument.getMetadata().getRawStorageId().equals(document.getId() + ":" + table.getName()));
+        assertEquals(translatedDocument.getId(), document.getId());
+        assertNotNull(translatedDocument.getMetadata());
+        assertEquals(translatedDocument.getMetadata().getId(), document.getId());
+        assertEquals(translatedDocument.getMetadata().getRawStorageId(), document.getId() + ":" + table.getName());
     }
 
     @Test
@@ -74,10 +76,10 @@ public class DocumentTranslatorTest {
 
         Document translatedDocument = translator.translate(table, document);
 
-        assert (translatedDocument.getMetadata() != null);
-        assert (translatedDocument.getId().equals(translatedDocument.getMetadata().getRawStorageId()));
-        assert (translatedDocument.getMetadata().getId().equals(document.getId()));
-        assert (translatedDocument.getMetadata().getRawStorageId().endsWith(Constants.rawKeyVersionToSuffixMap.get("2.0")));
+        assertNotNull(translatedDocument.getMetadata());
+        assertEquals(translatedDocument.getId(), translatedDocument.getMetadata().getRawStorageId());
+        assertEquals(translatedDocument.getMetadata().getId(), document.getId());
+        assertTrue(translatedDocument.getMetadata().getRawStorageId().endsWith(Constants.rawKeyVersionToSuffixMap.get("2.0")));
     }
 
     @Test
@@ -95,8 +97,8 @@ public class DocumentTranslatorTest {
 
         Document translatedBackDocument = translator.translateBack(translatedDocument);
 
-        assert (document.getId().equals(translatedBackDocument.getId()));
-        assert (document.getTimestamp() == translatedBackDocument.getTimestamp());
+        assertEquals(document.getId(), translatedBackDocument.getId());
+        assertEquals(document.getTimestamp(), translatedBackDocument.getTimestamp());
     }
 
     @Test
@@ -117,8 +119,8 @@ public class DocumentTranslatorTest {
 
         Document translatedBackDocument = translator.translateBack(translatedDocument);
 
-        assert (document.getId().equals(translatedBackDocument.getId()));
-        assert (document.getTimestamp() == translatedBackDocument.getTimestamp());
+        assertEquals(document.getId(), translatedBackDocument.getId());
+        assertEquals(document.getTimestamp(), translatedBackDocument.getTimestamp());
     }
 
 }

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/DocumentTranslatorTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/DocumentTranslatorTest.java
@@ -1,0 +1,124 @@
+package com.flipkart.foxtrot.core.querystore;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.foxtrot.common.Document;
+import com.flipkart.foxtrot.common.Table;
+import com.flipkart.foxtrot.core.TestUtils;
+import com.flipkart.foxtrot.core.datastore.impl.hbase.HbaseConfig;
+import com.flipkart.foxtrot.core.querystore.actions.Constants;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class DocumentTranslatorTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRawKeyVersion() {
+        HbaseConfig hbaseConfig = new HbaseConfig();
+        hbaseConfig.setRawKeyVersion(UUID.randomUUID().toString());
+        new DocumentTranslator(hbaseConfig);
+    }
+
+    @Test
+    public void testTranslationWithNullRawKeyVersion() {
+        HbaseConfig hbaseConfig = new HbaseConfig();
+        hbaseConfig.setRawKeyVersion(null);
+        DocumentTranslator translator = new DocumentTranslator(hbaseConfig);
+        Table table = new Table();
+        table.setName(UUID.randomUUID().toString());
+
+        Document document = new Document();
+        document.setId(UUID.randomUUID().toString());
+        document.setTimestamp(System.currentTimeMillis());
+        document.setData(mapper.createObjectNode().put("name", "rishabh"));
+
+        Document translatedDocument = translator.translate(table, document);
+
+        assert (translatedDocument.getId().equals(document.getId()));
+        assert (translatedDocument.getMetadata() != null);
+        assert (translatedDocument.getMetadata().getId().equals(document.getId()));
+        assert (translatedDocument.getMetadata().getRawStorageId().equals(document.getId() + ":" + table.getName()));
+    }
+
+    @Test
+    public void testTranslationWithRawKeyVersion1() {
+        DocumentTranslator translator = new DocumentTranslator(TestUtils.createHBaseConfigWithRawKeyV1());
+        Table table = new Table();
+        table.setName(UUID.randomUUID().toString());
+
+        Document document = new Document();
+        document.setId(UUID.randomUUID().toString());
+        document.setTimestamp(System.currentTimeMillis());
+        document.setData(mapper.createObjectNode().put("name", "rishabh"));
+
+        Document translatedDocument = translator.translate(table, document);
+
+        assert (translatedDocument.getId().equals(document.getId()));
+        assert (translatedDocument.getMetadata() != null);
+        assert (translatedDocument.getMetadata().getId().equals(document.getId()));
+        assert (translatedDocument.getMetadata().getRawStorageId().equals(document.getId() + ":" + table.getName()));
+    }
+
+    @Test
+    public void testTranslationWithRawKeyVersion2() {
+        DocumentTranslator translator = new DocumentTranslator(TestUtils.createHBaseConfigWithRawKeyV2());
+        Table table = new Table();
+        table.setName(UUID.randomUUID().toString());
+
+        Document document = new Document();
+        document.setId(UUID.randomUUID().toString());
+        document.setTimestamp(System.currentTimeMillis());
+        document.setData(mapper.createObjectNode().put("name", "rishabh"));
+
+        Document translatedDocument = translator.translate(table, document);
+
+        assert (translatedDocument.getMetadata() != null);
+        assert (translatedDocument.getId().equals(translatedDocument.getMetadata().getRawStorageId()));
+        assert (translatedDocument.getMetadata().getId().equals(document.getId()));
+        assert (translatedDocument.getMetadata().getRawStorageId().endsWith(Constants.rawKeyVersionToSuffixMap.get("2.0")));
+    }
+
+    @Test
+    public void testTranslationBackWithRawKeyVersion1() {
+        DocumentTranslator translator = new DocumentTranslator(TestUtils.createHBaseConfigWithRawKeyV1());
+        Table table = new Table();
+        table.setName(UUID.randomUUID().toString());
+
+        Document document = new Document();
+        document.setId(UUID.randomUUID().toString());
+        document.setTimestamp(System.currentTimeMillis());
+        document.setData(mapper.createObjectNode().put("name", "rishabh"));
+
+        Document translatedDocument = translator.translate(table, document);
+
+        Document translatedBackDocument = translator.translateBack(translatedDocument);
+
+        assert (document.getId().equals(translatedBackDocument.getId()));
+        assert (document.getTimestamp() == translatedBackDocument.getTimestamp());
+    }
+
+    @Test
+    public void testTranslationBackWithRawKeyVersion2() {
+        HbaseConfig hbaseConfig = new HbaseConfig();
+        hbaseConfig.setRawKeyVersion("2.0");
+
+        DocumentTranslator translator = new DocumentTranslator(hbaseConfig);
+        Table table = new Table();
+        table.setName(UUID.randomUUID().toString());
+
+        Document document = new Document();
+        document.setId(UUID.randomUUID().toString());
+        document.setTimestamp(System.currentTimeMillis());
+        document.setData(mapper.createObjectNode().put("name", "rishabh"));
+
+        Document translatedDocument = translator.translate(table, document);
+
+        Document translatedBackDocument = translator.translateBack(translatedDocument);
+
+        assert (document.getId().equals(translatedBackDocument.getId()));
+        assert (document.getTimestamp() == translatedBackDocument.getTimestamp());
+    }
+
+}

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchQueryStoreTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchQueryStoreTest.java
@@ -17,20 +17,17 @@ package com.flipkart.foxtrot.core.querystore.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.flipkart.foxtrot.common.Document;
-import com.flipkart.foxtrot.common.FieldType;
-import com.flipkart.foxtrot.common.FieldTypeMapping;
-import com.flipkart.foxtrot.common.TableFieldMapping;
+import com.flipkart.foxtrot.common.*;
 import com.flipkart.foxtrot.core.MockElasticsearchServer;
 import com.flipkart.foxtrot.core.TestUtils;
 import com.flipkart.foxtrot.core.datastore.DataStore;
 import com.flipkart.foxtrot.core.exception.ErrorCode;
 import com.flipkart.foxtrot.core.exception.FoxtrotException;
-import com.flipkart.foxtrot.core.querystore.DocumentTranslator;
+import com.flipkart.foxtrot.core.exception.FoxtrotExceptions;
 import com.flipkart.foxtrot.core.table.TableMetadataManager;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.shash.hbase.ds.RowKeyDistributorByHashPrefix;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
@@ -42,34 +39,39 @@ import org.mockito.Mockito;
 
 import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by rishabh.goyal on 16/04/14.
  */
 public class ElasticsearchQueryStoreTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
     private MockElasticsearchServer elasticsearchServer;
+    private DataStore dataStore;
     private ElasticsearchQueryStore queryStore;
-    private ObjectMapper mapper;
     private TableMetadataManager tableMetadataManager;
-    private final DocumentTranslator translator = new DocumentTranslator(new RowKeyDistributorByHashPrefix(
-            new RowKeyDistributorByHashPrefix.OneByteSimpleHash(32)));
 
     @Before
     public void setUp() throws Exception {
-        mapper = new ObjectMapper();
-        DataStore dataStore = TestUtils.getDataStore();
-        elasticsearchServer = new MockElasticsearchServer(UUID.randomUUID().toString());
+        this.dataStore = Mockito.mock(DataStore.class);
+
+        this.elasticsearchServer = new MockElasticsearchServer(UUID.randomUUID().toString());
         ElasticsearchConnection elasticsearchConnection = Mockito.mock(ElasticsearchConnection.class);
         when(elasticsearchConnection.getClient()).thenReturn(elasticsearchServer.getClient());
         ElasticsearchUtils.initializeMappings(elasticsearchConnection.getClient());
-        tableMetadataManager = Mockito.mock(TableMetadataManager.class);
+
+        this.tableMetadataManager = Mockito.mock(TableMetadataManager.class);
         when(tableMetadataManager.exists(TestUtils.TEST_TABLE_NAME)).thenReturn(true);
         when(tableMetadataManager.get(anyString())).thenReturn(TestUtils.TEST_TABLE);
-        queryStore = new ElasticsearchQueryStore(tableMetadataManager, elasticsearchConnection, dataStore, mapper);
+
+        this.queryStore = new ElasticsearchQueryStore(tableMetadataManager, elasticsearchConnection, dataStore, mapper);
     }
 
     @After
@@ -77,15 +79,36 @@ public class ElasticsearchQueryStoreTest {
         elasticsearchServer.shutdown();
     }
 
+
     @Test
-    public void testSaveSingle() throws Exception {
-        Document originalDocument = new Document();
-        originalDocument.setId(UUID.randomUUID().toString());
-        originalDocument.setTimestamp(System.currentTimeMillis());
-        JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
-        originalDocument.setData(data);
+    public void testSaveSingleRawKeyVersion1() throws Exception {
+        Table table = tableMetadataManager.get(TestUtils.TEST_TABLE_NAME);
+
+        Document originalDocument = createDummyDocument();
+        Document translatedDocument = TestUtils.translatedDocumentWithRowKeyVersion1(table, originalDocument);
+        doReturn(translatedDocument).when(dataStore).save(table, originalDocument);
         queryStore.save(TestUtils.TEST_TABLE_NAME, originalDocument);
-        final Document translatedDocument = translator.translate(tableMetadataManager.get(TestUtils.TEST_TABLE_NAME), originalDocument);
+
+        GetResponse getResponse = elasticsearchServer
+                .getClient()
+                .prepareGet(ElasticsearchUtils.getCurrentIndex(TestUtils.TEST_TABLE_NAME, originalDocument.getTimestamp()),
+                        ElasticsearchUtils.DOCUMENT_TYPE_NAME,
+                        originalDocument.getId())
+                .setFields("_timestamp").execute().actionGet();
+        assertTrue("Id should exist in ES", getResponse.isExists());
+        assertEquals("Id should match requestId", originalDocument.getId(), getResponse.getId());
+        assertEquals("Timestamp should match request timestamp", originalDocument.getTimestamp(), getResponse.getField("_timestamp").getValue());
+    }
+
+    @Test
+    public void testSaveSingleRawKeyVersion2() throws Exception {
+        Table table = tableMetadataManager.get(TestUtils.TEST_TABLE_NAME);
+
+        Document originalDocument = createDummyDocument();
+        Document translatedDocument = TestUtils.translatedDocumentWithRowKeyVersion2(table, originalDocument);
+        doReturn(translatedDocument).when(dataStore).save(table, originalDocument);
+        queryStore.save(TestUtils.TEST_TABLE_NAME, originalDocument);
+
         GetResponse getResponse = elasticsearchServer
                 .getClient()
                 .prepareGet(ElasticsearchUtils.getCurrentIndex(TestUtils.TEST_TABLE_NAME, originalDocument.getTimestamp()),
@@ -94,16 +117,12 @@ public class ElasticsearchQueryStoreTest {
                 .setFields("_timestamp").execute().actionGet();
         assertTrue("Id should exist in ES", getResponse.isExists());
         assertEquals("Id should match requestId", translatedDocument.getId(), getResponse.getId());
-        assertEquals("Timestamp should match request timestamp", translatedDocument.getTimestamp(), getResponse.getField("_timestamp").getValue());
+        assertEquals("Timestamp should match request timestamp", originalDocument.getTimestamp(), getResponse.getField("_timestamp").getValue());
     }
 
     @Test
     public void testSaveSingleInvalidTable() throws Exception {
-        Document expectedDocument = new Document();
-        expectedDocument.setId(UUID.randomUUID().toString());
-        expectedDocument.setTimestamp(System.currentTimeMillis());
-        JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
-        expectedDocument.setData(data);
+        Document expectedDocument = createDummyDocument();
         try {
             queryStore.save(TestUtils.TEST_TABLE + "-missing", expectedDocument);
             fail();
@@ -113,22 +132,75 @@ public class ElasticsearchQueryStoreTest {
     }
 
     @Test
-    public void testSaveBulk() throws Exception {
-        List<Document> documents = new Vector<Document>();
+    public void testSaveBulkRawKeyVersion1() throws Exception {
+        Table table = tableMetadataManager.get(TestUtils.TEST_TABLE_NAME);
+
+        List<Document> documents = Lists.newArrayList();
         for (int i = 0; i < 10; i++) {
-            documents.add(new Document(UUID.randomUUID().toString(),
-                    System.currentTimeMillis(),
-                    mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"))));
+            documents.add(createDummyDocument());
         }
+
+        List<Document> translatedDocuments = Lists.newArrayList();
+        translatedDocuments.addAll(documents
+                        .stream()
+                        .map(document -> TestUtils.translatedDocumentWithRowKeyVersion1(table, document))
+                        .collect(Collectors.toList())
+        );
+
+        doReturn(translatedDocuments).when(dataStore).saveAll(table, documents);
         queryStore.save(TestUtils.TEST_TABLE_NAME, documents);
-        final List<Document> translatedDocuemtns = translator.translate(tableMetadataManager.get(TestUtils.TEST_TABLE_NAME), documents);
-        for (Document document : translatedDocuemtns) {
+
+        for (Document document : documents) {
             GetResponse getResponse = elasticsearchServer
                     .getClient()
                     .prepareGet(ElasticsearchUtils.getCurrentIndex(TestUtils.TEST_TABLE_NAME, document.getTimestamp()),
                             ElasticsearchUtils.DOCUMENT_TYPE_NAME,
                             document.getId())
                     .setFields("_timestamp").execute().actionGet();
+            assertTrue("Id should exist in ES", getResponse.isExists());
+            assertEquals("Id should match requestId", document.getId(), getResponse.getId());
+            assertEquals("Timestamp should match request timestamp", document.getTimestamp(), getResponse.getField("_timestamp").getValue());
+        }
+    }
+
+    @Test
+    public void testSaveBulkRawKeyVersion2() throws Exception {
+        Table table = tableMetadataManager.get(TestUtils.TEST_TABLE_NAME);
+
+        List<Document> documents = Lists.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            documents.add(createDummyDocument());
+        }
+
+        List<Document> translatedDocuments = Lists.newArrayList();
+        translatedDocuments.addAll(documents
+                        .stream()
+                        .map(document -> TestUtils.translatedDocumentWithRowKeyVersion2(table, document))
+                        .collect(Collectors.toList())
+        );
+
+        doReturn(translatedDocuments).when(dataStore).saveAll(table, documents);
+        queryStore.save(TestUtils.TEST_TABLE_NAME, documents);
+
+        for (Document document : documents) {
+            GetResponse getResponse = elasticsearchServer
+                    .getClient()
+                    .prepareGet(ElasticsearchUtils.getCurrentIndex(TestUtils.TEST_TABLE_NAME, document.getTimestamp()),
+                            ElasticsearchUtils.DOCUMENT_TYPE_NAME,
+                            document.getId())
+                    .setFields("_timestamp").execute().actionGet();
+
+            assertFalse("Id should not exist in ES", getResponse.isExists());
+        }
+
+        for (Document document : translatedDocuments) {
+            GetResponse getResponse = elasticsearchServer
+                    .getClient()
+                    .prepareGet(ElasticsearchUtils.getCurrentIndex(TestUtils.TEST_TABLE_NAME, document.getTimestamp()),
+                            ElasticsearchUtils.DOCUMENT_TYPE_NAME,
+                            document.getId())
+                    .setFields("_timestamp").execute().actionGet();
+
             assertTrue("Id should exist in ES", getResponse.isExists());
             assertEquals("Id should match requestId", document.getId(), getResponse.getId());
             assertEquals("Timestamp should match request timestamp", document.getTimestamp(), getResponse.getField("_timestamp").getValue());
@@ -161,9 +233,7 @@ public class ElasticsearchQueryStoreTest {
     public void testSaveBulkInvalidTable() throws Exception {
         List<Document> documents = new Vector<Document>();
         for (int i = 0; i < 10; i++) {
-            documents.add(new Document(UUID.randomUUID().toString(),
-                    System.currentTimeMillis(),
-                    mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"))));
+            documents.add(createDummyDocument());
         }
         try {
             queryStore.save(TestUtils.TEST_TABLE + "-missing", documents);
@@ -173,23 +243,49 @@ public class ElasticsearchQueryStoreTest {
         }
     }
 
+
     @Test
-    public void testGetSingle() throws Exception {
-        String id = UUID.randomUUID().toString();
-        long timestamp = System.currentTimeMillis();
-        JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
-        Document document = new Document(id, System.currentTimeMillis(), data);
-        document.setTimestamp(timestamp);
+    public void testGetSingleRawKeyVersion1() throws Exception {
+        Table table = tableMetadataManager.get(TestUtils.TEST_TABLE_NAME);
+
+        Document document = createDummyDocument();
+        Document translatedDocument = TestUtils.translatedDocumentWithRowKeyVersion1(table, document);
+
+        doReturn(translatedDocument).when(dataStore).save(table, document);
+        doReturn(translatedDocument).when(dataStore).get(table, document.getId());
+
         queryStore.save(TestUtils.TEST_TABLE_NAME, document);
+
         elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
-        Document responseDocument = queryStore.get(TestUtils.TEST_TABLE_NAME, id);
+        Document responseDocument = queryStore.get(TestUtils.TEST_TABLE_NAME, document.getId());
         assertNotNull(responseDocument);
-        assertEquals(id, responseDocument.getId());
+        assertEquals(document.getId(), responseDocument.getId());
+        assertEquals("Timestamp should match request timestamp", document.getTimestamp(), responseDocument.getTimestamp());
+    }
+
+    @Test
+    public void testGetSingleRawKeyVersion2() throws Exception {
+        Table table = tableMetadataManager.get(TestUtils.TEST_TABLE_NAME);
+
+        Document document = createDummyDocument();
+        Document translatedDocument = TestUtils.translatedDocumentWithRowKeyVersion2(table, document);
+
+        doReturn(translatedDocument).when(dataStore).save(table, document);
+        doReturn(document).when(dataStore).get(table, translatedDocument.getId());
+
+        queryStore.save(TestUtils.TEST_TABLE_NAME, document);
+
+        elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
+        Document responseDocument = queryStore.get(TestUtils.TEST_TABLE_NAME, document.getId());
+        assertNotNull(responseDocument);
+        assertEquals(document.getId(), responseDocument.getId());
         assertEquals("Timestamp should match request timestamp", document.getTimestamp(), responseDocument.getTimestamp());
     }
 
     @Test
     public void testGetSingleInvalidId() throws Exception {
+        Table table = tableMetadataManager.get(TestUtils.TEST_TABLE_NAME);
+        doThrow(FoxtrotExceptions.createMissingDocumentException(table, UUID.randomUUID().toString())).when(dataStore).get(any(Table.class), anyString());
         try {
             queryStore.get(TestUtils.TEST_TABLE_NAME, UUID.randomUUID().toString());
             fail();
@@ -199,20 +295,29 @@ public class ElasticsearchQueryStoreTest {
     }
 
     @Test
-    public void testGetBulk() throws Exception {
-        Map<String, Document> idValues = Maps.newHashMap();
+    public void testGetBulkRawKeyVersion1() throws Exception {
+        Table table = tableMetadataManager.get(TestUtils.TEST_TABLE_NAME);
+
+        Map<String, Document> idValues = Maps.newLinkedHashMap();
+        Map<String, Document> translatedIdValues = Maps.newLinkedHashMap();
+
         List<String> ids = new Vector<String>();
         for (int i = 0; i < 10; i++) {
-            String id = UUID.randomUUID().toString();
-            ids.add(id);
-            idValues.put(id,
-                    new Document(id,
-                            System.currentTimeMillis(),
-                            mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"))));
-            idValues.get(id).setTimestamp(System.currentTimeMillis());
+            Document document = createDummyDocument();
+            Document translatedDocument = TestUtils.translatedDocumentWithRowKeyVersion1(table, document);
+
+            ids.add(document.getId());
+            idValues.put(document.getId(), document);
+            translatedIdValues.put(document.getId(), translatedDocument);
         }
+
+
+        doReturn(ImmutableList.copyOf(translatedIdValues.values())).when(dataStore).saveAll(table, ImmutableList.copyOf(idValues.values()));
+        doReturn(ImmutableList.copyOf(idValues.values())).when(dataStore).getAll(table, ids);
+
         queryStore.save(TestUtils.TEST_TABLE_NAME, ImmutableList.copyOf(idValues.values()));
         elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
+
         List<Document> responseDocuments = queryStore.getAll(TestUtils.TEST_TABLE_NAME, ids);
         HashMap<String, Document> responseIdValues = Maps.newHashMap();
         for (Document doc : responseDocuments) {
@@ -224,12 +329,54 @@ public class ElasticsearchQueryStoreTest {
             assertNotNull(responseIdValues.get(id));
             assertEquals(id, responseIdValues.get(id).getId());
             assertEquals("Timestamp should match request timestamp", idValues.get(id).getTimestamp(), responseIdValues.get(id).getTimestamp());
-            System.out.println("OK: " + id);
         }
     }
 
     @Test
+    public void testGetBulkRawKeyVersion2() throws Exception {
+        Table table = tableMetadataManager.get(TestUtils.TEST_TABLE_NAME);
+
+        Map<String, Document> idValues = Maps.newLinkedHashMap();
+        Map<String, Document> translatedIdValues = Maps.newLinkedHashMap();
+
+        List<String> ids = Lists.newArrayList();
+        List<String> translatedIds = Lists.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            Document document = createDummyDocument();
+            Document translatedDocument = TestUtils.translatedDocumentWithRowKeyVersion2(table, document);
+
+            ids.add(document.getId());
+            translatedIds.add(translatedDocument.getId());
+            idValues.put(document.getId(), document);
+            translatedIdValues.put(document.getId(), translatedDocument);
+        }
+
+        doReturn(ImmutableList.copyOf(translatedIdValues.values())).when(dataStore).saveAll(table, ImmutableList.copyOf(idValues.values()));
+        doReturn(ImmutableList.copyOf(idValues.values())).when(dataStore).getAll(table, translatedIds);
+
+        queryStore.save(TestUtils.TEST_TABLE_NAME, ImmutableList.copyOf(idValues.values()));
+        elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
+
+        List<Document> responseDocuments = queryStore.getAll(TestUtils.TEST_TABLE_NAME, ids);
+        HashMap<String, Document> responseIdValues = Maps.newHashMap();
+        for (Document doc : responseDocuments) {
+            responseIdValues.put(doc.getId(), doc);
+        }
+        assertNotNull("List of returned Documents should not be null", responseDocuments);
+        for (String id : ids) {
+            assertTrue("Requested Id should be present in response", responseIdValues.containsKey(id));
+            assertNotNull(responseIdValues.get(id));
+            assertEquals(id, responseIdValues.get(id).getId());
+            assertEquals("Timestamp should match request timestamp", idValues.get(id).getTimestamp(), responseIdValues.get(id).getTimestamp());
+        }
+    }
+
+
+    @Test
     public void testGetBulkInvalidIds() throws Exception {
+        Table table = tableMetadataManager.get(TestUtils.TEST_TABLE_NAME);
+        doThrow(FoxtrotExceptions.createMissingDocumentException(table, UUID.randomUUID().toString()))
+                .when(dataStore).getAll(any(Table.class), anyListOf(String.class));
         try {
             queryStore.getAll(TestUtils.TEST_TABLE_NAME, Arrays.asList(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
             fail();
@@ -240,6 +387,7 @@ public class ElasticsearchQueryStoreTest {
 
     @Test
     public void testGetFieldMappings() throws FoxtrotException, InterruptedException {
+        doReturn(TestUtils.getMappingDocuments(mapper)).when(dataStore).saveAll(any(Table.class), anyListOf(Document.class));
         queryStore.save(TestUtils.TEST_TABLE_NAME, TestUtils.getMappingDocuments(mapper));
         Thread.sleep(500);
 
@@ -277,27 +425,26 @@ public class ElasticsearchQueryStoreTest {
 
     @Test
     public void testEsClusterHealth() throws ExecutionException, InterruptedException, FoxtrotException {
-        List<Document> documents = new Vector<Document>();
+        List<Document> documents = Lists.newArrayList();
         for (int i = 0; i < 10; i++) {
-            documents.add(new Document(UUID.randomUUID().toString(),
-                    System.currentTimeMillis(),
-                    mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"))));
+            documents.add(createDummyDocument());
         }
+        doReturn(documents).when(dataStore).saveAll(any(Table.class), anyListOf(Document.class));
         queryStore.save(TestUtils.TEST_TABLE_NAME, documents);
         elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
         ClusterHealthResponse clusterHealth = queryStore.getClusterHealth();
-        assertEquals("elasticsearch",clusterHealth.getClusterName());
-        assertEquals(1,clusterHealth.getIndices().size());
+        assertEquals("elasticsearch", clusterHealth.getClusterName());
+        assertEquals(1, clusterHealth.getIndices().size());
     }
 
     @Test
     public void testEsNodesStats() throws FoxtrotException, ExecutionException, InterruptedException {
-        List<Document> documents = new Vector<Document>();
+        List<Document> documents = Lists.newArrayList();
         for (int i = 0; i < 10; i++) {
-            documents.add(new Document(UUID.randomUUID().toString(),
-                    System.currentTimeMillis(),
-                    mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"))));
+            documents.add(createDummyDocument());
         }
+        doReturn(documents).when(dataStore).saveAll(any(Table.class), anyListOf(Document.class));
+
         queryStore.save(TestUtils.TEST_TABLE_NAME, documents);
         elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
         NodesStatsResponse clusterHealth = queryStore.getNodeStats();
@@ -307,18 +454,29 @@ public class ElasticsearchQueryStoreTest {
 
     @Test
     public void testIndicesStats() throws FoxtrotException, ExecutionException, InterruptedException {
-        List<Document> documents = new Vector<Document>();
+        List<Document> documents = Lists.newArrayList();
         for (int i = 0; i < 10; i++) {
-            documents.add(new Document(UUID.randomUUID().toString(),
-                    System.currentTimeMillis(),
-                    mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"))));
+            documents.add(createDummyDocument());
         }
+        doReturn(documents).when(dataStore).saveAll(any(Table.class), anyListOf(Document.class));
+
         queryStore.save(TestUtils.TEST_TABLE_NAME, documents);
         elasticsearchServer.refresh(ElasticsearchUtils.getIndices(TestUtils.TEST_TABLE_NAME));
         IndicesStatsResponse clusterHealth = queryStore.getIndicesStats();
-        assertEquals(10,clusterHealth.getPrimaries().getDocs().getCount());
-        assertNotEquals(0,clusterHealth.getTotal().getStore().getSizeInBytes());
-        assertNotEquals(0,clusterHealth.getPrimaries().getStore().getSizeInBytes());
+        assertEquals(10, clusterHealth.getPrimaries().getDocs().getCount());
+        assertNotEquals(0, clusterHealth.getTotal().getStore().getSizeInBytes());
+        assertNotEquals(0, clusterHealth.getPrimaries().getStore().getSizeInBytes());
 
     }
+
+
+    private Document createDummyDocument() {
+        Document document = new Document();
+        document.setId(UUID.randomUUID().toString());
+        document.setTimestamp(System.currentTimeMillis());
+        JsonNode data = mapper.valueToTree(Collections.singletonMap("TEST_NAME", "SINGLE_SAVE_TEST"));
+        document.setData(data);
+        return document;
+    }
+
 }

--- a/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/FoxtrotServer.java
+++ b/foxtrot-server/src/main/java/com/flipkart/foxtrot/server/FoxtrotServer.java
@@ -27,6 +27,7 @@ import com.flipkart.foxtrot.core.common.DataDeletionManagerConfig;
 import com.flipkart.foxtrot.core.datastore.DataStore;
 import com.flipkart.foxtrot.core.datastore.impl.hbase.HBaseDataStore;
 import com.flipkart.foxtrot.core.datastore.impl.hbase.HbaseTableConnection;
+import com.flipkart.foxtrot.core.querystore.DocumentTranslator;
 import com.flipkart.foxtrot.core.querystore.QueryExecutor;
 import com.flipkart.foxtrot.core.querystore.QueryStore;
 import com.flipkart.foxtrot.core.querystore.actions.spi.AnalyticsLoader;
@@ -89,7 +90,8 @@ public class FoxtrotServer extends Service<FoxtrotServerConfiguration> {
         ElasticsearchUtils.setTableNamePrefix(configuration.getElasticsearch());
 
         TableMetadataManager tableMetadataManager = new DistributedTableMetadataManager(hazelcastConnection, elasticsearchConnection);
-        DataStore dataStore = new HBaseDataStore(HBaseTableConnection, objectMapper);
+        DataStore dataStore = new HBaseDataStore(HBaseTableConnection,
+                objectMapper, new DocumentTranslator(configuration.getHbase()));
         QueryStore queryStore = new ElasticsearchQueryStore(tableMetadataManager, elasticsearchConnection, dataStore, objectMapper);
         FoxtrotTableManager tableManager = new FoxtrotTableManager(tableMetadataManager, queryStore, dataStore);
         CacheManager cacheManager = new CacheManager(new DistributedCacheFactory(hazelcastConnection, objectMapper));


### PR DESCRIPTION
**Description**

This PR introduces backward compatibility for older row key structure. Also, rawKey are now versioned which helps if someone wants to continue using older row key formats.

**Why this ?** - Earlier assumption was that HBase rowKey would be prefixed during writes. It is possible that many clients have written custom ID generators and corresponding region splits in HBase tables. Changing row key format will render those regions useless and limits scale.
