### PR TITLE
Fixing bar chart UI issue. uiFilteredValues is set as empty array but…

### DIFF
--- a/foxtrot-server/src/main/resources/console/js/tiles/bar-tile.js
+++ b/foxtrot-server/src/main/resources/console/js/tiles/bar-tile.js
@@ -23,7 +23,7 @@ function BarTile() {
     this.period = 0;
     this.selectedFilters = null;
     this.uniqueValues = [];
-    this.uiFilteredValues = [];
+    this.uiFilteredValues;
 }
 
 BarTile.prototype = new Tile();


### PR DESCRIPTION
Fixing bar chart UI issue. uiFilteredValues is set as empty array but at the time of filter it is expecting to have correct items in this array if it is not null.