### PR TITLE
Moved heavy dependencies inside modules

### DIFF
--- a/foxtrot-core/pom.xml
+++ b/foxtrot-core/pom.xml
@@ -18,6 +18,27 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-core</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sematext.hbase.ds</groupId>
+            <artifactId>hbase-ds</artifactId>
+            <version>0.0.2-SNAPSHOT</version>
+        </dependency>
+        <!-- Hazelcast Marathon discovery SPI -->
+        <dependency>
+            <groupId>com.marathon.hazelcast.servicediscovery</groupId>
+            <artifactId>hazelcast-marathon-discovery</artifactId>
+            <version>0.0.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-server</artifactId>
             <version>${hbase.version}</version>

--- a/foxtrot-server/pom.xml
+++ b/foxtrot-server/pom.xml
@@ -15,6 +15,11 @@
 
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-core</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-assets</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,24 +88,18 @@
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-core</artifactId>
+            <artifactId>dropwizard-jackson</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-validation</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sematext.hbase.ds</groupId>
-            <artifactId>hbase-ds</artifactId>
-            <version>0.0.2-SNAPSHOT</version>
-        </dependency>
-        <!-- Hazelcast Marathon discovery SPI -->
-        <dependency>
-            <groupId>com.marathon.hazelcast.servicediscovery</groupId>
-            <artifactId>hazelcast-marathon-discovery</artifactId>
-            <version>0.0.3</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
Currently using the common module to use the model classes brings in loads of dependencies that are not used. The dependencies have been moved to their respective correct positions, and lighter ones added to the top.